### PR TITLE
Restore OpenSpec base spec validity

### DIFF
--- a/openspec/changes/repair-openspec-base-spec-purpose/.openspec.yaml
+++ b/openspec/changes/repair-openspec-base-spec-purpose/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: expense-app
+created: 2026-07-16

--- a/openspec/changes/repair-openspec-base-spec-purpose/design.md
+++ b/openspec/changes/repair-openspec-base-spec-purpose/design.md
@@ -1,0 +1,87 @@
+## Context
+
+The repository workflow engine performs a pinned OpenSpec archive in a
+temporary detached worktree and then strictly validates every rebuilt base
+spec. The post-merge pilot reached that step and exposed three legacy files
+whose content has requirements but whose introductory section is named
+`Current-State Scope` instead of the schema-required `Purpose`.
+
+The active change artifacts and the workflow engine remain the trust boundary.
+OpenSpec is planning/transformation machinery only; it does not authorize task
+completion, commits, or archive transitions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the complete normative base-spec set pass the repository-pinned strict
+  OpenSpec validation.
+- Preserve every existing requirement, scenario, and scope statement.
+- Add the validation to a test file already executed by the registered
+  `workflow-tests` check.
+- Keep the task path scope exact and database-free.
+
+**Non-Goals:**
+
+- Rewording or extending product requirements.
+- Repairing the retained `apps/web` gitlink or legacy documentation.
+- Changing OpenSpec parsing, the workflow archive implementation, or the check
+  registry.
+- Treating a direct OpenSpec command as completion or archive authority.
+
+## Decisions
+
+### Exercise the pinned adapter from the registered contract suite
+
+Add a repository-baseline test to the existing OpenSpec adapter integration
+suite, which is imported by `contracts.test.ts` and therefore executed by the
+registered `workflow-tests` check. The test calls the same pinned adapter used
+by the workflow engine and requires a valid result.
+
+This is preferred over a new check ID because the pilot should repair the
+baseline without expanding workflow configuration. It is preferred over a
+text-only heading assertion because strict validation covers the actual
+OpenSpec schema and future base specs.
+
+### Preserve prose and requirements; rename only the invalid heading
+
+For each of the three known invalid base specs, replace
+`## Current-State Scope` with `## Purpose`. The paragraph already describes the
+specification's purpose and scope, so moving or rewriting content would add
+unnecessary semantic risk.
+
+### Keep archive fail-closed
+
+Do not weaken the archive validator or accept malformed diagnostic payloads.
+The repository must become valid so the existing engine-owned transition can
+complete. RED is the new registered contract failing against the old baseline;
+GREEN is the same test and pinned strict validation passing after the three
+heading repairs.
+
+## Risks / Trade-offs
+
+- **Risk: A heading-only edit is mistaken for a requirements change.** → Limit
+  the diff to the three exact heading lines and verify the remaining file
+  content is unchanged.
+- **Risk: The contract increases workflow-test duration.** → Reuse the pinned
+  adapter and one validation invocation; do not add a new workflow check.
+- **Risk: Another invalid base spec appears later.** → The all-spec contract
+  fails closed and reports the drift before a future archive pilot.
+- **Risk: OpenSpec returns unsafe diagnostics.** → Preserve the adapter's
+  strict payload validation; do not special-case or suppress diagnostics.
+
+## Migration Plan
+
+1. Commit this planning baseline through `workflow plan-commit`.
+2. Start Task 1.1 and add the repository-baseline contract; demonstrate RED.
+3. Rename the three headings and demonstrate GREEN with the targeted contract,
+   the configured workflow checks, and pinned strict validation.
+4. Complete and commit through the engine, merge through the active main
+   ruleset, then retry the original engine-owned archive.
+
+Rollback is a rebase PR reverting the task commit. Reverting would intentionally
+restore the archive blocker and make the repository-baseline contract fail.
+
+## Open Questions
+
+None.

--- a/openspec/changes/repair-openspec-base-spec-purpose/guard.json
+++ b/openspec/changes/repair-openspec-base-spec-purpose/guard.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "changeId": "repair-openspec-base-spec-purpose",
+  "tasks": {
+    "1.1": {
+      "allowedPaths": [
+        "openspec/specs/category-management/spec.md",
+        "openspec/specs/group-collaboration/spec.md",
+        "openspec/specs/identity-and-access/spec.md",
+        "packages/workflow-engine/test/openspec-adapter.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    }
+  }
+}

--- a/openspec/changes/repair-openspec-base-spec-purpose/proposal.md
+++ b/openspec/changes/repair-openspec-base-spec-purpose/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+The post-merge archive pilot exposed three legacy normative base specs that do
+not satisfy the pinned OpenSpec schema because they use `Current-State Scope`
+where a `Purpose` section is required. Their baseline drift prevents every
+managed change from completing the engine-owned archive transition.
+
+This follows the active post-merge pilot item in `docs/ROADMAP.md`; the repair
+is required before the completed `correct-codeowner-identity` change can be
+archived.
+
+## What Changes
+
+- Add an executable repository contract that all normative OpenSpec base specs
+  pass pinned strict validation.
+- Preserve the existing scope prose while renaming the three nonconforming
+  section headings to `Purpose`.
+- Limit implementation scope to the validation contract and the three known
+  invalid base specs.
+- Do not change any requirement, scenario, product behavior, API, or retained
+  legacy path.
+
+## Capabilities
+
+### New Capabilities
+
+- `openspec-base-spec-validity`: Require normative base specs to retain the
+  schema sections needed for pinned strict validation and archive readiness.
+
+### Modified Capabilities
+
+None. The existing category, collaboration, and identity requirements remain
+unchanged; this repair only restores their required document structure.
+
+## Impact
+
+Affected paths are limited to the workflow-engine OpenSpec adapter contract
+test and the `category-management`, `group-collaboration`, and
+`identity-and-access` base specs. This is planning/test/documentation-only and
+does not require database access. The heading repairs are exempt from
+RED-GREEN-REFACTOR as documentation-only, while the repository contract itself
+will be demonstrated RED before the headings are repaired and GREEN after.

--- a/openspec/changes/repair-openspec-base-spec-purpose/specs/openspec-base-spec-validity/spec.md
+++ b/openspec/changes/repair-openspec-base-spec-purpose/specs/openspec-base-spec-validity/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Normative Base Specs Pass Pinned Strict Validation
+
+The repository SHALL keep every normative OpenSpec base specification
+compatible with the repository-pinned strict validator. Each base
+specification MUST contain the required `Purpose` and `Requirements` sections,
+and validation failure MUST block managed archive readiness rather than being
+ignored or bypassed.
+
+#### Scenario: Repository baseline is valid
+
+- **WHEN** the registered repository contract validates all normative base
+  specifications with the pinned OpenSpec adapter
+- **THEN** strict validation succeeds for the complete base-spec set
+- **THEN** the result is eligible to serve as evidence for a later
+  engine-owned archive transition
+
+#### Scenario: A base spec loses required structure
+
+- **WHEN** any normative base specification lacks a schema-required section
+- **THEN** the registered repository contract fails
+- **THEN** the workflow engine continues to reject archive readiness until a
+  managed repair restores validity
+
+### Requirement: Structural Repairs Preserve Requirement Semantics
+
+A repair for legacy base-spec structure SHALL preserve the existing purpose
+prose, requirements, and scenarios unless a separate delta explicitly changes
+their semantics. A documentation-only repair MUST remain limited to the exact
+invalid structural elements.
+
+#### Scenario: Legacy scope heading is repaired
+
+- **WHEN** an existing scope paragraph already states a specification's
+  purpose but uses a nonconforming section heading
+- **THEN** the repair renames that heading to `Purpose`
+- **THEN** all requirement and scenario content remains unchanged

--- a/openspec/changes/repair-openspec-base-spec-purpose/tasks.md
+++ b/openspec/changes/repair-openspec-base-spec-purpose/tasks.md
@@ -1,0 +1,7 @@
+## 1. Restore Base-Spec Archive Readiness
+
+- [ ] 1.1 Add a registered repository contract that demonstrates RED against
+      the invalid base-spec baseline, rename only the three legacy
+      `Current-State Scope` headings to `Purpose`, and demonstrate GREEN with
+      the pinned strict validator and managed non-database checks without
+      changing any requirement or scenario content.

--- a/openspec/changes/repair-openspec-base-spec-purpose/tasks.md
+++ b/openspec/changes/repair-openspec-base-spec-purpose/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Restore Base-Spec Archive Readiness
 
-- [ ] 1.1 Add a registered repository contract that demonstrates RED against
+- [x] 1.1 Add a registered repository contract that demonstrates RED against
       the invalid base-spec baseline, rename only the three legacy
       `Current-State Scope` headings to `Purpose`, and demonstrate GREEN with
       the pinned strict validator and managed non-database checks without

--- a/openspec/specs/category-management/spec.md
+++ b/openspec/specs/category-management/spec.md
@@ -1,6 +1,6 @@
 # Category Management Specification
 
-## Current-State Scope
+## Purpose
 
 This specification records the category behavior that exists today. The mobile
 in-memory catalog and the authenticated API ledger catalog are separate

--- a/openspec/specs/group-collaboration/spec.md
+++ b/openspec/specs/group-collaboration/spec.md
@@ -1,6 +1,6 @@
 # Group Collaboration Specification
 
-## Current-State Scope
+## Purpose
 
 This specification records the independent mobile in-memory group model and
 authenticated API ledger model that exist today. It does not assert mobile/API

--- a/openspec/specs/identity-and-access/spec.md
+++ b/openspec/specs/identity-and-access/spec.md
@@ -1,6 +1,6 @@
 # Identity and Access Specification
 
-## Current-State Scope
+## Purpose
 
 This specification records the mobile session-local identity and the API
 account/access capabilities that exist today. The mobile app does not yet use

--- a/packages/workflow-engine/test/openspec-adapter.integration.test.ts
+++ b/packages/workflow-engine/test/openspec-adapter.integration.test.ts
@@ -11,6 +11,13 @@ import {
 import { parseInstructions } from '../src/openspec-payloads.ts';
 import { isWorkflowError, sourceRepositoryRoot } from './fixture.ts';
 
+test('repository base specs satisfy pinned strict validation', () => {
+  const validation =
+    createOpenSpecAdapter(sourceRepositoryRoot).validateAllSpecs();
+
+  assert.equal(validation.valid, true);
+});
+
 test('OpenSpec adapter pins argv, cwd, environment, and temporary homes', () => {
   const capturePath = path.join(
     os.tmpdir(),


### PR DESCRIPTION
## Summary

- add a registered pinned-OpenSpec contract for the complete normative base-spec set
- rename only three legacy `Current-State Scope` headings to schema-required `Purpose`
- preserve all existing purpose prose, requirements, scenarios, and product behavior
- unblock engine-owned archive validation discovered by the post-merge pilot

## RED → GREEN

- RED: the targeted registered contract failed with `OPENSPEC_PAYLOAD_INVALID` against the existing three-spec baseline drift
- GREEN: the same contract passed after the three one-line heading repairs
- pinned strict all-spec validation: 7/7 base specs valid

## Managed workflow evidence

- `workflow check`: four configured non-database checks passed; exact paths; no unexpected paths
- `workflow finish`: independent rerun passed
- `workflow documents validate`: passed after task commit
- managed commit trailers: `Change: repair-openspec-base-spec-purpose`, `Task: 1.1`

This change does not weaken archive validation and does not invoke a direct lifecycle transition. Its purpose is to make the repository baseline satisfy the existing fail-closed contract so the original `correct-codeowner-identity` archive can proceed.
