### PR TITLE
Convert apps/web to a monorepo directory

### DIFF
--- a/.github/workflows/workflow-assurance.yml
+++ b/.github/workflows/workflow-assurance.yml
@@ -16,23 +16,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
-      - name: Prepare retained gitlink checkout compatibility
-        run: |
-          git init .
-          git remote add origin "${{ github.server_url }}/${{ github.repository }}"
-          git config --file .gitmodules submodule.apps/web.path apps/web
-          git config --file .gitmodules submodule.apps/web.url "${{ github.server_url }}/${{ github.repository }}"
-
       - name: Checkout exact PR head
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
-          clean: false
-
-      - name: Remove transient gitlink checkout compatibility
-        run: rm -- .gitmodules
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -54,9 +43,3 @@ jobs:
           pnpm workflow ci
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"
-
-      - name: Restore transient gitlink checkout compatibility
-        if: always()
-        run: |
-          git config --file .gitmodules submodule.apps/web.path apps/web
-          git config --file .gitmodules submodule.apps/web.url "${{ github.server_url }}/${{ github.repository }}"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,16 @@
+# Web Surface Placeholder
+
+`apps/web` is an ordinary monorepo directory, but it does not currently contain
+a web application. The repository's former entry at this path was an
+unconfigured Git gitlink whose referenced commit and source repository could
+not be recovered.
+
+Do not infer a deployed or supported web capability from this placeholder. A
+future implementation must use a managed OpenSpec change to either:
+
+- import recovered source with its repository URL and revision recorded, after
+  auditing it for secrets and generated artifacts; or
+- scaffold a new web workspace from explicit product and architecture
+  requirements, with its lint, typecheck, test, and build checks registered.
+
+Do not recreate the malformed gitlink or invent a `.gitmodules` URL.

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,7 +8,7 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`1.2` — Replace the transitional contract with a failing permanent contract for ordinary `apps/web` Git index entries and credential-free exact-head checkout, add the documented placeholder directory, remove the transient checkout compatibility phases, and prove structural Git, frozen-install, targeted contract, and authoritative non-database checks.
+None — all tasks are complete.
 
 ## Next Task
 
@@ -16,7 +16,7 @@ None.
 
 ## Current Focus
 
-Replace the transitional contract with a failing permanent contract for ordinary `apps/web` Git index entries and credential-free exact-head checkout, add the documented placeholder directory, remove the transient checkout compatibility phases, and prove structural Git, frozen-install, targeted contract, and authoritative non-database checks.
+Prepare the completed change for explicit archival review.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -4,11 +4,11 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Change
 
-`integrate-openspec-with-workflow`
+`convert-apps-web-to-monorepo-directory`
 
 ## Current Task
 
-None — all tasks are complete.
+`1.2` — Replace the transitional contract with a failing permanent contract for ordinary `apps/web` Git index entries and credential-free exact-head checkout, add the documented placeholder directory, remove the transient checkout compatibility phases, and prove structural Git, frozen-install, targeted contract, and authoritative non-database checks.
 
 ## Next Task
 
@@ -16,7 +16,7 @@ None.
 
 ## Current Focus
 
-Prepare the completed change for explicit archival review.
+Replace the transitional contract with a failing permanent contract for ordinary `apps/web` Git index entries and credential-free exact-head checkout, add the documented placeholder directory, remove the transient checkout compatibility phases, and prove structural Git, frozen-install, targeted contract, and authoritative non-database checks.
 
 ## Known Blockers
 
@@ -26,7 +26,7 @@ Prepare the completed change for explicit archival review.
 ## References
 
 - [Roadmap](ROADMAP.md)
-- [Active change](../openspec/changes/integrate-openspec-with-workflow/)
-- [Workflow assurance delta](../openspec/changes/integrate-openspec-with-workflow/specs/workflow-assurance/spec.md)
+- [Active change](../openspec/changes/convert-apps-web-to-monorepo-directory/)
+- [Workflow assurance delta](../openspec/changes/convert-apps-web-to-monorepo-directory/specs/workflow-assurance/spec.md)
 - [Issue log](ISSUE_LOG.md)
 - [System architecture](architecture/ARCHITECTURE.md)

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/.openspec.yaml
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: expense-app
+created: 2026-07-16

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
@@ -1,0 +1,126 @@
+## Context
+
+The parent repository has always recorded `apps/web` as gitlink mode `160000`
+at commit `4126efb678c2e692d82862b6366a0405573d2922`, but that object is unavailable
+and no `.gitmodules` mapping identifies a source. Fresh worktrees therefore
+contain an empty path, and Git's submodule commands fail before application
+tooling is involved.
+
+The protected `workflow-assurance` job currently synthesizes `.gitmodules`
+metadata around pinned checkout so `actions/checkout` can remove credentials.
+That runner-only bridge was appropriate for the post-merge pilot, but it is not
+a valid permanent repository model. The active ruleset requires the real
+workflow-assurance result, so the conversion and removal must land together in
+one managed task and be proven on GitHub.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Replace the gitlink with an ordinary tracked directory without inventing
+  source provenance.
+- Remove all checkout steps and assertions that exist only for the malformed
+  gitlink.
+- Preserve exact pull-request head checkout, full reachable history, a pinned
+  checkout action, and `persist-credentials: false`.
+- Make ordinary submodule inspection succeed and reject future gitlinks under
+  `apps/web` through a registered RED -> GREEN contract.
+- Complete the task, protected merge, archive, and idempotent replay through
+  repository workflow authority.
+
+**Non-Goals:**
+
+- Implementing or scaffolding a Next.js application.
+- Recovering source by guessing a submodule URL or treating the parent
+  repository as its own submodule.
+- Changing workspace dependencies, package manifests, rulesets, applications,
+  databases, or workflow-engine production code.
+- Reformatting unrelated files or resolving existing non-required CI baselines.
+
+## Decisions
+
+### Select the placeholder path after an explicit source-recovery gate
+
+The task creates only `apps/web/README.md`. The decision gate checked the
+parent object database, all refs and worktrees, local Codespace and common
+backup locations, and the maintainer's visible GitHub repositories. None
+contained the referenced commit or a verifiable expense web repository.
+
+Importing an unrelated project or generating a framework skeleton is rejected
+because either would manufacture provenance and imply unsupported web
+behavior. The README instead states the intended surface, its placeholder
+status, and the conditions for a future managed scaffolding or recovery task.
+
+### Treat the Git index as the structural authority
+
+The regression contract invokes Git against the repository root and rejects
+any `160000` entry at or below `apps/web`. A filesystem-only assertion is
+insufficient because an empty directory can coexist with a gitlink index entry.
+The same contract verifies that the workflow no longer contains preparation,
+removal, restoration, `.gitmodules`, or `clean: false` compatibility markers.
+
+The contract continues to assert the permanent security properties of pinned
+checkout, exact event-head selection, `fetch-depth: 0`, and
+`persist-credentials: false`. A failure is hard and blocks the registered
+`workflow-tests` check; there is no compatibility fallback.
+
+### Convert the tree and workflow in one managed task
+
+Removing only the shim would break checkout while the gitlink remains.
+Converting only the gitlink would leave unnecessary runner mutation and dead
+security-sensitive code. One narrowly scoped task makes the repository tree,
+workflow, and registered contract change atomically.
+
+Planning has its own workflow-owned commit. Task scope names the gitlink path,
+its future descendants, the assurance workflow, and the single registered
+contract file. The workflow report is the authority for allowed paths and
+non-database checks; Markdown completion is not evidence.
+
+## Trust Boundaries and Evidence
+
+- The committed Git index, not the working-directory shape, proves that
+  `apps/web` is ordinary tracked content.
+- The registered contract and workflow source prove permanent checkout
+  invariants before GitHub executes repository-controlled package commands.
+- `git submodule status --recursive` proves no unconfigured submodule mapping
+  remains.
+- The task workflow report proves exact path scope and the four registered
+  workflow-engine checks.
+- GitHub's required `workflow-assurance` check recomputes the plan/task commit
+  evidence from the pull-request head without a ruleset bypass.
+
+## Risks / Trade-offs
+
+- **Recovered source appears later** -> Import it only through a new managed
+  change with recorded URL, revision, secret audit, and appropriate web checks.
+- **The placeholder is mistaken for a web application** -> State explicitly
+  that it contains no runtime and supports no capability claim.
+- **A future gitlink reappears below `apps/web`** -> Fail the registered
+  Git-index contract on any mode `160000` entry.
+- **Checkout security is weakened while removing the shim** -> Preserve and
+  assert the pinned action, exact event head, full history, and disabled
+  credential persistence.
+- **The tree conversion is partially applied** -> Workflow path checks and the
+  task commit bind the index, README, workflow, and contract as one transition.
+
+## Migration Plan
+
+1. Commit this complete planning tree with `workflow plan-commit`.
+2. Start Task 1.1 and change only the registered contract to record the RED
+   failure against the retained gitlink and workaround.
+3. Remove the gitlink, add the placeholder README, and remove only the three
+   transient compatibility phases plus `clean: false` from assurance checkout.
+4. Run the targeted contract, structural Git checks, frozen install, and the
+   authoritative task check before complete-task, finish, and workflow commit.
+5. Push and rebase-merge only after the active ruleset's real
+   `workflow-assurance` check passes.
+6. From an updated default branch, run workflow archive twice, verify
+   idempotency, and merge the archive pull request through the same rule.
+
+Rollback before merge is a correction on the managed branch. Rollback after
+merge is another managed ordinary-directory change; recreating the malformed
+gitlink or restoring the transient shim is not an acceptable shortcut.
+
+## Open Questions
+
+None.

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
@@ -64,17 +64,28 @@ checkout, exact event-head selection, `fetch-depth: 0`, and
 `persist-credentials: false`. A failure is hard and blocks the registered
 `workflow-tests` check; there is no compatibility fallback.
 
-### Convert the tree and workflow in one managed task
+### Cross the Git file-to-directory boundary in two managed task commits
 
-Removing only the shim would break checkout while the gitlink remains.
-Converting only the gitlink would leave unnecessary runner mutation and dead
-security-sensitive code. One narrowly scoped task makes the repository tree,
-workflow, and registered contract change atomically.
+Git cannot represent deletion of an indexed gitlink and untracked descendants
+below the same path as one unstaged worktree projection. The workflow engine
+correctly reserves staging for `finish`, so manually removing the gitlink from
+the index before finish is forbidden.
 
-Planning has its own workflow-owned commit. Task scope names the gitlink path,
-its future descendants, the assurance workflow, and the single registered
-contract file. The workflow report is the authority for allowed paths and
-non-database checks; Markdown completion is not evidence.
+Task 1.1 therefore adds a RED -> GREEN transition contract and removes only the
+gitlink. Its committed baseline has no entry at `apps/web` while the checkout
+shim remains. Task 1.2 then adds the ordinary README, replaces the transitional
+contract with the permanent index/workflow contract, and removes the shim.
+Both commits land in one protected pull request, so the default branch observes
+only the final coherent directory state.
+
+Removing the shim in Task 1.1 is rejected because checkout still needs it for
+the pull-request head until the final tree exists. Adding the README before the
+gitlink deletion is rejected because Git hides descendants beneath the indexed
+gitlink from the engine's unstaged change inspection.
+
+Planning has its own workflow-owned revision commit. Each task has exact path
+scope and the same four registered non-database checks. The workflow report is
+the authority for allowed paths and completion; Markdown state is not evidence.
 
 ## Trust Boundaries and Evidence
 
@@ -100,26 +111,32 @@ non-database checks; Markdown completion is not evidence.
 - **Checkout security is weakened while removing the shim** -> Preserve and
   assert the pinned action, exact event head, full history, and disabled
   credential persistence.
-- **The tree conversion is partially applied** -> Workflow path checks and the
-  task commit bind the index, README, workflow, and contract as one transition.
+- **The first task commit lacks a web path** -> Keep it only as an intermediate
+  commit in the protected branch; Task 2 supplies the final ordinary directory
+  before the pull request may merge.
 
 ## Migration Plan
 
 1. Commit this complete planning tree with `workflow plan-commit`.
-2. Start Task 1.1 and change only the registered contract to record the RED
-   failure against the retained gitlink and workaround.
-3. Remove the gitlink, add the placeholder README, and remove only the three
-   transient compatibility phases plus `clean: false` from assurance checkout.
-4. Run the targeted contract, structural Git checks, frozen install, and the
-   authoritative task check before complete-task, finish, and workflow commit.
-5. Push and rebase-merge only after the active ruleset's real
+2. Start Task 1.1, add a transitional contract that fails while the `apps/web`
+   worktree path exists, remove the empty gitlink path without staging it, and
+   let workflow finish stage and commit the deletion.
+3. Start Task 1.2 and replace the transitional contract with the permanent
+   Git-index and checkout contract, observe RED against the absent placeholder
+   and retained shim, then add `apps/web/README.md` and remove only the three
+   transient compatibility phases plus `clean: false`.
+4. For each task, run the targeted contract and authoritative checks before
+   complete-task, finish, and workflow commit. After Task 1.2, additionally run
+   structural Git checks and frozen install.
+5. Push and rebase-merge both task commits only after the active ruleset's real
    `workflow-assurance` check passes.
 6. From an updated default branch, run workflow archive twice, verify
    idempotency, and merge the archive pull request through the same rule.
 
-Rollback before merge is a correction on the managed branch. Rollback after
-merge is another managed ordinary-directory change; recreating the malformed
-gitlink or restoring the transient shim is not an acceptable shortcut.
+Rollback before merge completes Task 1.2 or corrects the managed branch; the
+intermediate deletion commit must not merge alone. Rollback after merge is
+another managed ordinary-directory change; recreating the malformed gitlink or
+restoring the transient shim is not an acceptable shortcut.
 
 ## Open Questions
 

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/guard.json
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/guard.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "changeId": "convert-apps-web-to-monorepo-directory",
+  "tasks": {
+    "1.1": {
+      "allowedPaths": [
+        "apps/web",
+        "apps/web/**",
+        ".github/workflows/workflow-assurance.yml",
+        "packages/workflow-engine/test/contracts.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    }
+  }
+}

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/guard.json
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/guard.json
@@ -5,6 +5,18 @@
     "1.1": {
       "allowedPaths": [
         "apps/web",
+        "packages/workflow-engine/test/contracts.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "1.2": {
+      "allowedPaths": [
+        "apps/web",
         "apps/web/**",
         ".github/workflows/workflow-assurance.yml",
         "packages/workflow-engine/test/contracts.test.ts"

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
@@ -1,0 +1,71 @@
+## Why
+
+`apps/web` is recorded as an unconfigured gitlink whose referenced commit is
+unavailable, so fresh clones have no usable web source and ordinary submodule
+inspection fails. `workflow-assurance` currently carries runner-only
+compatibility metadata solely to tolerate this malformed tree state; `ISS-205`
+requires the repository to recover a valid web source before making web
+capability claims.
+
+## What Changes
+
+- Replace the malformed `apps/web` gitlink with an ordinary tracked monorepo
+  directory.
+- Use an honest `apps/web/README.md` placeholder because the source-recovery
+  decision gate found no recoverable web repository or commit.
+- Remove the transient `.gitmodules` preparation, removal, and restoration
+  steps from `workflow-assurance`.
+- Replace the retained-gitlink regression contract with a permanent contract
+  that rejects gitlinks under `apps/web`, rejects the retired workaround, and
+  preserves pinned credential-free exact-head checkout with full history.
+- Prove ordinary Git and submodule inspection, frozen dependency installation,
+  and managed workflow checks without inventing a submodule URL.
+
+## Scope
+
+The managed task is limited to `apps/web`,
+`.github/workflows/workflow-assurance.yml`, and
+`packages/workflow-engine/test/contracts.test.ts`. Planning artifacts record
+the selected source strategy and managed evidence.
+
+## Non-Goals
+
+- Reconstructing or fabricating a Next.js application without recovered
+  source.
+- Adding a persistent `.gitmodules` entry or guessing an external repository
+  URL.
+- Claiming that the placeholder implements a web capability.
+- Changing API, mobile, database, dependency, workspace, ruleset, or workflow
+  engine production behavior.
+- Mixing unrelated formatting, API timing, archival, or legacy-document work
+  into this structural correction.
+
+## Decision Gate Result
+
+The gitlink references `4126efb678c2e692d82862b6366a0405573d2922`,
+which is absent from the parent object database and every local or remote ref.
+No usable source was found in existing repository worktrees, the maintainer's
+Codespace and common local backup locations, or the maintainer's visible GitHub
+repositories. The mutually exclusive placeholder strategy is therefore
+selected. The future scaffolding task must start from explicit requirements or
+recovered provenance rather than treating this README as application source.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `repository-governance`: Replace retained-gitlink checkout compatibility
+  requirements with a permanent ordinary-directory and credential-free
+  checkout invariant.
+
+## Impact
+
+Git changes the `apps/web` tree entry from mode `160000` to ordinary tracked
+files. GitHub Actions loses the transient compatibility steps but retains the
+pinned checkout action, exact pull-request head selection, full reachable
+history, and `persist-credentials: false`. No runtime application, API,
+database, dependency, or public interface changes.

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
@@ -23,10 +23,11 @@ capability claims.
 
 ## Scope
 
-The managed task is limited to `apps/web`,
+The managed tasks are limited to `apps/web`,
 `.github/workflows/workflow-assurance.yml`, and
 `packages/workflow-engine/test/contracts.test.ts`. Planning artifacts record
-the selected source strategy and managed evidence.
+the selected source strategy, the Git transition boundary, and managed
+evidence.
 
 ## Non-Goals
 

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/specs/repository-governance/spec.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/specs/repository-governance/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Credential-Free Assurance Checkout Compatibility
+
+The pull-request assurance workflow SHALL check out the exact event head with
+full reachable history without persisting repository credentials. The
+repository MUST represent `apps/web` only with ordinary tracked files and
+directories, MUST NOT retain a gitlink at or below that path, and MUST NOT
+create transient `.gitmodules` compatibility metadata during assurance
+checkout.
+
+#### Scenario: Ordinary web directory checkout
+
+- **GIVEN** `apps/web` contains only ordinary tracked files and directories
+- **AND** no `.gitmodules` entry is required for that path
+- **WHEN** the pull-request assurance job checks out the event head
+- **THEN** the pinned checkout completes without persisting credentials
+- **AND** the workflow verifies the exact event head with full reachable
+  history
+- **AND** no transient submodule compatibility step runs before or after
+  repository-controlled commands
+
+#### Scenario: Gitlink regression under the web path
+
+- **GIVEN** Git records `apps/web` or one of its descendants with mode
+  `160000`
+- **WHEN** the registered repository-governance contract runs
+- **THEN** workflow assurance fails before the change can be completed or
+  merged

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Web Tree Conversion
 
-- [ ] 1.1 Add a failing transitional contract for removal of the empty
+- [x] 1.1 Add a failing transitional contract for removal of the empty
       `apps/web` worktree path, remove the malformed gitlink without pre-staging
       it, retain checkout compatibility until the replacement exists, and let
       workflow finish authorize the deletion commit with all registered

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
@@ -1,7 +1,12 @@
 ## 1. Web Tree Conversion
 
-- [ ] 1.1 Add a failing registered contract for ordinary `apps/web` Git index
-      entries and permanent credential-free exact-head checkout, replace the
-      malformed gitlink with the documented placeholder directory, remove the
-      transient checkout compatibility phases, and prove structural Git,
-      frozen-install, targeted contract, and authoritative non-database checks.
+- [ ] 1.1 Add a failing transitional contract for removal of the empty
+      `apps/web` worktree path, remove the malformed gitlink without pre-staging
+      it, retain checkout compatibility until the replacement exists, and let
+      workflow finish authorize the deletion commit with all registered
+      non-database checks.
+- [ ] 1.2 Replace the transitional contract with a failing permanent contract
+      for ordinary `apps/web` Git index entries and credential-free exact-head
+      checkout, add the documented placeholder directory, remove the transient
+      checkout compatibility phases, and prove structural Git, frozen-install,
+      targeted contract, and authoritative non-database checks.

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
@@ -1,0 +1,7 @@
+## 1. Web Tree Conversion
+
+- [ ] 1.1 Add a failing registered contract for ordinary `apps/web` Git index
+      entries and permanent credential-free exact-head checkout, replace the
+      malformed gitlink with the documented placeholder directory, remove the
+      transient checkout compatibility phases, and prove structural Git,
+      frozen-install, targeted contract, and authoritative non-database checks.

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/tasks.md
@@ -5,7 +5,7 @@
       it, retain checkout compatibility until the replacement exists, and let
       workflow finish authorize the deletion commit with all registered
       non-database checks.
-- [ ] 1.2 Replace the transitional contract with a failing permanent contract
+- [x] 1.2 Replace the transitional contract with a failing permanent contract
       for ordinary `apps/web` Git index entries and credential-free exact-head
       checkout, add the documented placeholder directory, remove the transient
       checkout compatibility phases, and prove structural Git, frozen-install,

--- a/packages/workflow-engine/test/contracts.test.ts
+++ b/packages/workflow-engine/test/contracts.test.ts
@@ -94,6 +94,16 @@ test('workflow assurance contains retained-gitlink checkout compatibility around
   assert.ok(verify < restore);
 });
 
+test('apps/web gitlink removal phase leaves no worktree path', () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+
+  assert.equal(
+    fs.existsSync(path.join(repositoryRoot, 'apps/web')),
+    false,
+    'the malformed apps/web gitlink worktree path must be removed before its ordinary replacement is added',
+  );
+});
+
 test('parseTasks reads ordered checkbox tasks', () => {
   const tasks = parseTasks(`
 # Tasks

--- a/packages/workflow-engine/test/contracts.test.ts
+++ b/packages/workflow-engine/test/contracts.test.ts
@@ -45,7 +45,32 @@ test('runner security suite is portable to the package working directory', () =>
   );
 });
 
-test('workflow assurance contains retained-gitlink checkout compatibility around repository code', () => {
+test('workflow assurance checks out an ordinary apps/web directory without gitlink compatibility', () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+  const webEntries = execFileSync(
+    'git',
+    ['ls-files', '--stage', '--', 'apps/web'],
+    {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+    },
+  )
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  for (const entry of webEntries) {
+    assert.doesNotMatch(
+      entry,
+      /^160000\s/,
+      `apps/web must not contain a gitlink: ${entry}`,
+    );
+  }
+  assert.ok(
+    fs.existsSync(path.join(repositoryRoot, 'apps/web/README.md')),
+    'apps/web must contain its ordinary-directory placeholder',
+  );
+
   const workflow = fs.readFileSync(
     path.resolve(
       import.meta.dirname,
@@ -54,54 +79,22 @@ test('workflow assurance contains retained-gitlink checkout compatibility around
     'utf8',
   );
 
+  assert.match(workflow, /uses: actions\/checkout@[0-9a-f]{40}/);
   assert.match(
     workflow,
-    /- name: Prepare retained gitlink checkout compatibility/,
+    /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
   );
-  assert.match(workflow, /git init \./);
-  assert.match(
-    workflow,
-    /git remote add origin "\$\{\{ github\.server_url \}\}\/\$\{\{ github\.repository \}\}"/,
-  );
-  assert.match(
-    workflow,
-    /git config --file \.gitmodules submodule\.apps\/web\.path apps\/web/,
-  );
-  assert.match(workflow, /clean: false/);
-  assert.match(
-    workflow,
-    /- name: Remove transient gitlink checkout compatibility\n\s+run: rm -- \.gitmodules/,
-  );
-  assert.match(
-    workflow,
-    /- name: Restore transient gitlink checkout compatibility\n\s+if: always\(\)/,
-  );
+  assert.match(workflow, /fetch-depth: 0/);
+  assert.match(workflow, /persist-credentials: false/);
+  assert.doesNotMatch(workflow, /retained gitlink/i);
+  assert.doesNotMatch(workflow, /transient gitlink/i);
+  assert.doesNotMatch(workflow, /\.gitmodules/);
+  assert.doesNotMatch(workflow, /clean: false/);
 
-  const prepare = workflow.indexOf(
-    '- name: Prepare retained gitlink checkout compatibility',
-  );
   const checkout = workflow.indexOf('- name: Checkout exact PR head');
-  const remove = workflow.indexOf(
-    '- name: Remove transient gitlink checkout compatibility',
-  );
   const verify = workflow.indexOf('- name: Recompute workflow assurance');
-  const restore = workflow.indexOf(
-    '- name: Restore transient gitlink checkout compatibility',
-  );
-  assert.ok(prepare < checkout);
-  assert.ok(checkout < remove);
-  assert.ok(remove < verify);
-  assert.ok(verify < restore);
-});
-
-test('apps/web gitlink removal phase leaves no worktree path', () => {
-  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
-
-  assert.equal(
-    fs.existsSync(path.join(repositoryRoot, 'apps/web')),
-    false,
-    'the malformed apps/web gitlink worktree path must be removed before its ordinary replacement is added',
-  );
+  assert.ok(checkout >= 0);
+  assert.ok(checkout < verify);
 });
 
 test('parseTasks reads ordered checkbox tasks', () => {


### PR DESCRIPTION
## Summary

- convert the malformed `apps/web` gitlink into an ordinary monorepo directory
- record the unrecoverable-source decision honestly with a placeholder README instead of inventing a submodule URL
- remove the transient checkout compatibility phases while preserving pinned, credential-free exact-PR-head checkout
- add a permanent repository contract that rejects future `apps/web` gitlinks and checkout regressions

## Source recovery gate

The recorded gitlink object `4126efb678c2e692d82862b6366a0405573d2922` is unavailable locally and from repository refs/history. No recoverable `apps/web` source repository was found, so this PR intentionally creates only `apps/web/README.md`; it does not claim to restore an application.

## Managed workflow

Git cannot represent deletion of a gitlink and untracked descendants beneath the same path as one unstaged projection. The change therefore uses two atomic managed tasks:

1. remove the malformed gitlink while retaining checkout compatibility
2. add the ordinary directory, install the permanent contract, and remove the compatibility shim

## Verification

- `pnpm workflow ci --base f9195884167576f6d1f1f437e6ce5536f2d96357 --head ad1e1fcf5229a4da099d446bacfdbcedf3468bef --json`
- `node --test --experimental-strip-types packages/workflow-engine/test/contracts.test.ts` (47 passed)
- `pnpm workflow validate-change convert-apps-web-to-monorepo-directory --json`
- `pnpm exec openspec validate convert-apps-web-to-monorepo-directory --strict`
- `pnpm install --frozen-lockfile --ignore-scripts`
- `git submodule status --recursive`
- `git ls-files --stage -- apps/web` reports `100644 apps/web/README.md` and no `160000` entry

No database tests were required or run. No Spectra lifecycle or command was used.
