### PR TITLE
Repair apps/web archive delta

### DIFF
--- a/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/design.md
@@ -87,6 +87,25 @@ Planning has its own workflow-owned revision commit. Each task has exact path
 scope and the same four registered non-database checks. The workflow report is
 the authority for allowed paths and completion; Markdown state is not evidence.
 
+### Repair the post-merge archive delta without weakening the invariant
+
+Pinned OpenSpec 1.6 refuses to archive a `MODIFIED` requirement when its delta
+omits a scenario already present in the base requirement. The first archive
+attempt therefore failed closed before changing files because the delta
+replaced the retained-gitlink scenario with new ordinary-directory scenarios.
+
+A planning-only revision preserves the exact historical scenario heading but
+rewrites its body as a negative regression case: an unconfigured retained
+gitlink is rejected by the registered contract and cannot merge. This satisfies
+OpenSpec's no-silent-scenario-loss rule while keeping the permanent ordinary-
+directory invariant; it does not restore checkout compatibility metadata or
+permit a gitlink.
+
+No implementation task is created because delta specs are planning authority
+and task commits are forbidden from mutating them. The repair is exempt from
+RED -> GREEN TDD; its evidence is strict OpenSpec validation, local and remote
+PR assurance, and a successful idempotent archive replay.
+
 ## Trust Boundaries and Evidence
 
 - The committed Git index, not the working-directory shape, proves that
@@ -130,7 +149,10 @@ the authority for allowed paths and completion; Markdown state is not evidence.
    structural Git checks and frozen install.
 5. Push and rebase-merge both task commits only after the active ruleset's real
    `workflow-assurance` check passes.
-6. From an updated default branch, run workflow archive twice, verify
+6. If archive detects scenario-loss incompatibility, submit a planning-only
+   revision that retains the historical scenario as an explicit gitlink-
+   regression case, and merge the repair through the same protected workflow.
+7. From an updated default branch, run workflow archive twice, verify
    idempotency, and merge the archive pull request through the same rule.
 
 Rollback before merge completes Task 1.2 or corrects the managed branch; the

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/proposal.md
@@ -18,6 +18,9 @@ capability claims.
 - Replace the retained-gitlink regression contract with a permanent contract
   that rejects gitlinks under `apps/web`, rejects the retired workaround, and
   preserves pinned credential-free exact-head checkout with full history.
+- Preserve the existing retained-gitlink scenario identity as an explicit
+  regression case so pinned OpenSpec can safely merge the modified requirement
+  without dropping historical coverage during archive.
 - Prove ordinary Git and submodule inspection, frozen dependency installation,
   and managed workflow checks without inventing a submodule URL.
 
@@ -68,5 +71,7 @@ None.
 Git changes the `apps/web` tree entry from mode `160000` to ordinary tracked
 files. GitHub Actions loses the transient compatibility steps but retains the
 pinned checkout action, exact pull-request head selection, full reachable
-history, and `persist-credentials: false`. No runtime application, API,
+history, and `persist-credentials: false`. The post-merge planning repair adds
+only archive-compatible regression wording to the delta spec; it does not
+restore the shim or change runtime behavior. No runtime application, API,
 database, dependency, or public interface changes.

--- a/openspec/changes/convert-apps-web-to-monorepo-directory/specs/repository-governance/spec.md
+++ b/openspec/changes/convert-apps-web-to-monorepo-directory/specs/repository-governance/spec.md
@@ -20,6 +20,15 @@ checkout.
 - **AND** no transient submodule compatibility step runs before or after
   repository-controlled commands
 
+#### Scenario: Retained gitlink has no configured submodule URL
+
+- **GIVEN** a proposed repository tree retains the `apps/web` gitlink
+- **AND** no persistent `.gitmodules` entry assigns that gitlink a URL
+- **WHEN** the registered repository-governance contract runs
+- **THEN** workflow assurance rejects the gitlink regression before merge
+- **AND** no transient compatibility metadata is synthesized to mask the
+  invalid tree
+
 #### Scenario: Gitlink regression under the web path
 
 - **GIVEN** Git records `apps/web` or one of its descendants with mode


### PR DESCRIPTION
## Summary

- preserve the historical retained-gitlink scenario identity in the modified repository-governance delta
- rewrite that scenario as an explicit negative regression case: the gitlink is rejected and no compatibility metadata may mask it
- document why this is a planning-only archive repair and does not restore the retired checkout shim

## Why

The first managed archive attempt failed closed before changing files. Pinned OpenSpec 1.6 reported `archive_spec_update_failed` because a `MODIFIED` requirement may not silently drop a scenario already present in its base requirement. This revision preserves the scenario heading with the new permanent invariant.

Delta specs are planning authority, so this correction is committed only by `workflow plan-commit`; no implementation task or hand-authored commit is used.

## Verification

- `pnpm workflow validate-change convert-apps-web-to-monorepo-directory --json`
- `pnpm exec openspec validate convert-apps-web-to-monorepo-directory --strict`
- `pnpm workflow ci --base 63de6920b0e86fce8adeb124a9a9056161ec4059 --head a0f286ba5fcb8ac3c77af62bd58def81f270dc30 --json`
- Prettier check for all three revised planning files

This PR changes no application, workflow YAML, base spec, dependency, or database file. No Spectra lifecycle or command was used.
