### PR TITLE
Unify format check authority

### DIFF
--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -4,11 +4,11 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Change
 
-`convert-apps-web-to-monorepo-directory`
+`unify-format-check-authority`
 
 ## Current Task
 
-None — all tasks are complete.
+`1.2` — Add a failing repository routing contract, then make the existing `format:check` package entry point delegate to `run-check workflow-format` so GitHub, local verification, managed checks, and replay share the unchanged registry definition.
 
 ## Next Task
 
@@ -16,7 +16,7 @@ None.
 
 ## Current Focus
 
-Prepare the completed change for explicit archival review.
+Add a failing repository routing contract, then make the existing `format:check` package entry point delegate to `run-check workflow-format` so GitHub, local verification, managed checks, and replay share the unchanged registry definition.
 
 ## Known Blockers
 
@@ -26,7 +26,7 @@ Prepare the completed change for explicit archival review.
 ## References
 
 - [Roadmap](ROADMAP.md)
-- [Active change](../openspec/changes/convert-apps-web-to-monorepo-directory/)
-- [Workflow assurance delta](../openspec/changes/convert-apps-web-to-monorepo-directory/specs/workflow-assurance/spec.md)
+- [Active change](../openspec/changes/unify-format-check-authority/)
+- [Workflow assurance delta](../openspec/changes/unify-format-check-authority/specs/workflow-assurance/spec.md)
 - [Issue log](ISSUE_LOG.md)
 - [System architecture](architecture/ARCHITECTURE.md)

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,7 +8,7 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`1.2` — Add a failing repository routing contract, then make the existing `format:check` package entry point delegate to `run-check workflow-format` so GitHub, local verification, managed checks, and replay share the unchanged registry definition.
+None — all tasks are complete.
 
 ## Next Task
 
@@ -16,7 +16,7 @@ None.
 
 ## Current Focus
 
-Add a failing repository routing contract, then make the existing `format:check` package entry point delegate to `run-check workflow-format` so GitHub, local verification, managed checks, and replay share the unchanged registry definition.
+Prepare the completed change for explicit archival review.
 
 ## Known Blockers
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -230,6 +230,28 @@ least two independent eligible human maintainers exist. Until those remote
 rules are configured, local and workflow-file enforcement must not be described
 as merge authority.
 
+### Standalone registered checks
+
+Use the evidence-only entry point below when local verification or an external
+CI job must execute exactly one non-destructive check from
+`workflow/checks.json`:
+
+```bash
+pnpm workflow run-check <check-id> --json
+```
+
+The command requires a clean checkout, resolves the named registry entry,
+executes it through the same pinned runner used by managed checks and replay,
+binds the result to current HEAD, and rejects checkout mutation. It fails before
+execution for an unknown or destructive check. Its structured result is check
+evidence only: it cannot authorize task completion, staging, commit, archive,
+or a merge.
+
+CI and package-script adapters must delegate to this command instead of copying
+a registered command or maintaining another path scope. In particular,
+formatting verification resolves `workflow-format`; the registry entry remains
+the sole authority for its Prettier paths.
+
 ## Controlled Issues and Documents
 
 ### Issues

--- a/openspec/changes/unify-format-check-authority/.openspec.yaml
+++ b/openspec/changes/unify-format-check-authority/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: expense-app
+created: 2026-07-16

--- a/openspec/changes/unify-format-check-authority/design.md
+++ b/openspec/changes/unify-format-check-authority/design.md
@@ -1,0 +1,103 @@
+## Context
+
+The repository already has a versioned check registry at `workflow/checks.json`.
+Managed task evidence and historical CI replay resolve check IDs through that
+registry, pin the runner closure, apply database policy, execute the registered
+command, and reject checkout mutation. The `workflow-format` entry deliberately
+owns a reviewed subset of repository paths.
+
+The GitHub formatting workflow instead calls `pnpm run format:check`, whose
+current script executes `prettier --check .`. That second scope includes
+workflow-generated documents and pre-existing OpenSpec assets outside
+`workflow-format`. PR #48 therefore passed managed replay but failed the GitHub
+formatting job. Formatting the reported files would rewrite canonical generated
+output and conceal the authority split.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `workflow/checks.json` the only source of the formatting check command,
+  runner, database classification, and path scope.
+- Give GitHub Actions and local verification a supported way to execute one
+  registered check by ID.
+- Reuse the existing runner pinning, environment, mutation detection, and
+  repository validation boundaries.
+- Preserve the current `workflow-format` definition byte-for-byte so historical
+  task evidence and replay remain valid.
+
+**Non-Goals:**
+
+- Formatting, ignoring, or otherwise editing the eight files reported by the
+  repository-wide Prettier invocation.
+- Changing generated-document canonical output, OpenSpec schemas/base specs,
+  check scope, dependencies, product code, or database policy.
+- Allowing standalone execution of destructive database checks.
+
+## Decisions
+
+### 1. Add `workflow run-check <check-id>`
+
+The CLI will expose a narrow command that resolves exactly one check from the
+current registry and executes it through the existing pinned check runner. It
+will require a clean checkout, bind execution to the current HEAD, reject an
+unknown check ID, reject any check marked `destructiveDatabase`, reject worktree
+mutation, validate repository state, and return structured check evidence.
+
+Reusing the existing runner is preferred to reading JSON and spawning a command
+inside GitHub YAML because a YAML implementation would duplicate runner
+resolution and security policy while treating only the command array as shared.
+
+### 2. Route the existing package verification script through the engine
+
+`format:check` will call `pnpm workflow run-check workflow-format --json`.
+GitHub Actions already calls `pnpm run format:check`, so the workflow file does
+not need its own check ID, path list, or command. Local verification, the GitHub
+job, managed task checks, and replay will all resolve the unchanged registry
+entry.
+
+Keeping the package script as a small adapter preserves the familiar developer
+entry point without granting it independent formatting authority. The mutating
+`format` convenience script is not evidence and remains unchanged.
+
+### 3. Prove routing and failure boundaries with existing registered checks
+
+Integration coverage will establish RED evidence for successful registered
+execution, unknown-check rejection, destructive-check rejection, dirty-checkout
+rejection, and mutation detection. Repository contracts will assert that the
+package script delegates to the workflow command and that `workflow-format` is
+unchanged from the planning base.
+
+## Risks / Trade-offs
+
+- **The standalone command could become a general bypass around task policy.**
+  → It produces check evidence only, grants no task/completion/commit authority,
+  requires a clean checkout, and refuses destructive checks.
+- **Changing the package script could accidentally recurse into itself.**
+  → The registered `workflow-format` command invokes the pinned Prettier binary
+  directly, never the package script.
+- **A future CI job could again duplicate a registry command.**
+  → Contracts pin the adapter form and documentation names the registry as the
+  authority.
+- **PR #48 remains red until the repair reaches `main`.**
+  → Merge this independent change first, then re-trigger PR #48 against the new
+  base without modifying or formatting its eight reported files.
+
+## Migration Plan
+
+1. Commit this planning-only change through `workflow plan-commit`.
+2. Add failing command/adapter contracts, implement the runner-backed command,
+   and update command documentation.
+3. Complete and commit the task through the managed lifecycle; prove the
+   historical `workflow-format` JSON subtree is unchanged and run full branch
+   CI.
+4. Push and merge the independent repair PR.
+5. Re-trigger PR #48 against updated `main`; do not rewrite generated artifacts.
+6. Archive this change only after its merge is proven on the default branch.
+
+Rollback is a separately reviewed logical revert of the adapter and command.
+The registry definition requires no rollback because it never changes.
+
+## Open Questions
+
+None. The pilot failure and the existing runner boundaries determine the repair.

--- a/openspec/changes/unify-format-check-authority/guard.json
+++ b/openspec/changes/unify-format-check-authority/guard.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "changeId": "unify-format-check-authority",
+  "tasks": {
+    "1.1": {
+      "allowedPaths": [
+        "docs/WORKFLOW.md",
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/registered-check.ts",
+        "packages/workflow-engine/test/session.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "1.2": {
+      "allowedPaths": [
+        "package.json",
+        "packages/workflow-engine/test/contracts.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    }
+  }
+}

--- a/openspec/changes/unify-format-check-authority/proposal.md
+++ b/openspec/changes/unify-format-check-authority/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The post-merge pilot exposed two independent formatting authorities: managed
+tasks and replay use the registered `workflow-format` definition, while GitHub
+Actions runs the broader `prettier --check .` package script. The broader job
+rejects canonical generated artifacts and pre-existing OpenSpec files that the
+registered check intentionally does not own, so CI can block a valid managed
+change even when workflow replay passes.
+
+This is a CI-governance defect tracked under the workflow-assurance activation
+work in `docs/issues/issues.yaml` (`ISS-003`).
+
+## What Changes
+
+- Add a workflow-engine command that executes one registered non-destructive
+  check by ID through the same registry loader and pinned runner used by managed
+  workflow evidence.
+- Change the GitHub formatting job to invoke the registered `workflow-format`
+  check through that command instead of maintaining its own repository-wide
+  Prettier scope.
+- Add contract and integration coverage proving the command rejects unknown or
+  destructive checks and preserves the registered check definition as the only
+  formatting authority.
+- Document when agents and CI should use the single-check command.
+- Preserve `workflow/checks.json` and the historical `workflow-format`
+  definition byte-for-byte.
+
+Scope is limited to CI/workflow-engine governance, tests, the GitHub formatting
+workflow, and command documentation. No application, generated document,
+OpenSpec schema/spec baseline, formatting output, dependency, or database state
+is changed.
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-check-authority`: Defines how external CI invokes one registered workflow
+  check without duplicating its command, runner, or path scope.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+Affected surfaces are the workflow CLI and check runner, workflow-engine tests,
+`.github/workflows/format.yml`, `AGENTS.md`, and `docs/WORKFLOW.md`. The change
+adds no dependency and grants no new database or Git commit authority.

--- a/openspec/changes/unify-format-check-authority/specs/ci-check-authority/spec.md
+++ b/openspec/changes/unify-format-check-authority/specs/ci-check-authority/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Registered Checks Are the Sole CI Command Authority
+
+External CI and local verification SHALL resolve a named check through the
+versioned workflow check registry and execute it through the repository-owned
+workflow runner. An adapter command or CI workflow MUST NOT maintain a second
+command, runner, or path-scope definition for that check.
+
+#### Scenario: GitHub runs the formatting check
+
+- **WHEN** the GitHub formatting job invokes its local verification entry point
+- **THEN** the workflow engine resolves `workflow-format` from
+  `workflow/checks.json`
+- **THEN** the unchanged registered command and path scope are executed
+
+#### Scenario: Historical definition is replayed
+
+- **WHEN** historical task evidence references `workflow-format`
+- **THEN** replay continues to use the definition committed with that evidence
+- **THEN** the CI adapter introduces no alternate formatting scope
+
+### Requirement: Standalone Registered Check Execution Is Fail-Closed
+
+The workflow CLI SHALL allow exactly one registered non-destructive check to be
+executed by ID against a clean current checkout. It MUST pin the registered
+runner, bind execution to current HEAD, reject unknown or destructive checks,
+reject checkout mutation, and return structured evidence without granting task,
+completion, staging, commit, or archive authority.
+
+#### Scenario: Registered non-destructive check passes
+
+- **WHEN** an operator executes a known non-destructive check in a clean checkout
+- **THEN** the engine executes the registered command through its pinned runner
+- **THEN** the result identifies the check, outcome, runner digest, and database
+  classification
+
+#### Scenario: Check ID is unknown
+
+- **WHEN** standalone execution names a check absent from the registry
+- **THEN** the command fails before spawning a process
+
+#### Scenario: Check is destructive
+
+- **WHEN** standalone execution names a check marked `destructiveDatabase`
+- **THEN** the command fails without accepting database credentials or executing
+  the check
+
+#### Scenario: Checkout is dirty or mutated
+
+- **WHEN** the checkout is dirty before execution or the check changes it
+- **THEN** the command fails and produces no authoritative passing result
+
+### Requirement: Formatting Scope Remains Historically Stable
+
+The authority-unification migration MUST preserve the complete
+`workflow-format` definition in `workflow/checks.json` byte-for-byte and MUST
+NOT format, ignore, or rewrite files merely because the superseded global
+Prettier invocation reported them.
+
+#### Scenario: Migration is reviewed
+
+- **WHEN** the repair task is compared with its planning base
+- **THEN** the `workflow-format` registry definition is identical
+- **THEN** generated documents and unrelated OpenSpec artifacts are unchanged

--- a/openspec/changes/unify-format-check-authority/tasks.md
+++ b/openspec/changes/unify-format-check-authority/tasks.md
@@ -3,7 +3,7 @@
 - [x] 1.1 Add failing workflow integration coverage, then implement the
       fail-closed `run-check <check-id>` command by reusing the registered pinned
       runner and document its evidence-only authority boundary.
-- [ ] 1.2 Add a failing repository routing contract, then make the existing
+- [x] 1.2 Add a failing repository routing contract, then make the existing
       `format:check` package entry point delegate to `run-check workflow-format`
       so GitHub, local verification, managed checks, and replay share the
       unchanged registry definition.

--- a/openspec/changes/unify-format-check-authority/tasks.md
+++ b/openspec/changes/unify-format-check-authority/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Registered Check Authority
 
-- [ ] 1.1 Add failing workflow integration coverage, then implement the
+- [x] 1.1 Add failing workflow integration coverage, then implement the
       fail-closed `run-check <check-id>` command by reusing the registered pinned
       runner and document its evidence-only authority boundary.
 - [ ] 1.2 Add a failing repository routing contract, then make the existing

--- a/openspec/changes/unify-format-check-authority/tasks.md
+++ b/openspec/changes/unify-format-check-authority/tasks.md
@@ -1,0 +1,9 @@
+## 1. Registered Check Authority
+
+- [ ] 1.1 Add failing workflow integration coverage, then implement the
+      fail-closed `run-check <check-id>` command by reusing the registered pinned
+      runner and document its evidence-only authority boundary.
+- [ ] 1.2 Add a failing repository routing contract, then make the existing
+      `format:check` package entry point delegate to `run-check workflow-format`
+      so GitHub, local verification, managed checks, and replay share the
+      unchanged registry definition.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "prepare": "husky",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format:check": "pnpm workflow run-check workflow-format --json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "workflow": "node --experimental-strip-types packages/workflow-engine/src/cli.ts",

--- a/packages/workflow-engine/src/cli.ts
+++ b/packages/workflow-engine/src/cli.ts
@@ -36,6 +36,7 @@ import {
 import { validateManagedDocuments } from './managed-documents.ts';
 import { diagnoseOpenSpec } from './openspec-doctor.ts';
 import { commitPlanningTransition } from './planning-transition.ts';
+import { runRegisteredCheck } from './registered-check.ts';
 import { loadStableValidatedChangeContract } from './validated-contract-context.ts';
 
 type CommandResult = Record<string, unknown>;
@@ -183,6 +184,13 @@ function dispatch(args: string[], cwd: string): CommandResult {
     case 'check':
       requireArgumentCount(command, rest, 1, 1);
       return { command, ok: true, result: checkSession(cwd, rest[0]) };
+    case 'run-check':
+      requireArgumentCount(command, rest, 1, 1);
+      return {
+        command,
+        ok: true,
+        result: runRegisteredCheck(cwd, rest[0], process.env),
+      };
     case 'ci': {
       if (rest.length !== 4 || rest[0] !== '--base' || rest[2] !== '--head') {
         throw usage(
@@ -418,6 +426,7 @@ function usageText(): string {
     '  pnpm workflow start <change-id> --task <task-id> [--json]',
     '  pnpm workflow status [session-id] [--json]',
     '  pnpm workflow check <session-id> [--json]',
+    '  pnpm workflow run-check <check-id> [--json]',
     '  pnpm workflow ci --base <commit> --head <commit> [--json]',
     '  pnpm workflow adapter evaluate [--json]',
     '  pnpm workflow issue <add|update|close|render|validate> ... [--json]',

--- a/packages/workflow-engine/src/registered-check.ts
+++ b/packages/workflow-engine/src/registered-check.ts
@@ -1,0 +1,61 @@
+import type { CheckEvidence } from './check-runner.ts';
+import { runCiChecks } from './ci-checks.ts';
+import { loadChecksConfig } from './contracts.ts';
+import { ExitCode, workflowError } from './errors.ts';
+import { discoverRepository } from './git.ts';
+
+export type RegisteredCheckResult = {
+  head: string;
+  check: CheckEvidence;
+};
+
+export function runRegisteredCheck(
+  cwd: string,
+  checkId: string,
+  environment: NodeJS.ProcessEnv,
+): RegisteredCheckResult {
+  const repository = discoverRepository(cwd);
+  if (repository.statusEntries.length > 0) {
+    throw workflowError(
+      'STANDALONE_CHECK_DIRTY_WORKTREE',
+      'Standalone registered checks require a clean checkout.',
+      ExitCode.staleState,
+      {
+        details: { statusEntryCount: repository.statusEntries.length },
+        recovery:
+          'Commit or remove controlled checkout changes before running the registered check.',
+      },
+    );
+  }
+
+  const checks = loadChecksConfig(repository.repositoryRoot).checks;
+  if (!Object.hasOwn(checks, checkId)) {
+    throw workflowError(
+      'CI_CHECK_UNKNOWN',
+      `Check registry does not contain ${checkId}.`,
+      ExitCode.guard,
+      { details: { checkId } },
+    );
+  }
+  const definition = checks[checkId]!;
+  if (definition.destructiveDatabase) {
+    throw workflowError(
+      'STANDALONE_DESTRUCTIVE_CHECK',
+      `Standalone execution refuses destructive check ${checkId}.`,
+      ExitCode.unsafeEnvironment,
+      {
+        details: { checkId },
+        recovery:
+          'Run destructive checks only through an authorized managed task with explicit disposable database evidence.',
+      },
+    );
+  }
+
+  const evidence = runCiChecks(
+    repository.repositoryRoot,
+    repository.head,
+    [checkId],
+    environment,
+  );
+  return { head: repository.head, check: evidence[0]! };
+}

--- a/packages/workflow-engine/test/contracts.test.ts
+++ b/packages/workflow-engine/test/contracts.test.ts
@@ -97,6 +97,53 @@ test('workflow assurance checks out an ordinary apps/web directory without gitli
   assert.ok(checkout < verify);
 });
 
+test('format verification delegates to the unchanged registered authority', () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, 'package.json'), 'utf8'),
+  );
+  assert.equal(
+    manifest.scripts['format:check'],
+    'pnpm workflow run-check workflow-format --json',
+  );
+
+  const formatWorkflow = fs.readFileSync(
+    path.join(repositoryRoot, '.github/workflows/format.yml'),
+    'utf8',
+  );
+  assert.match(formatWorkflow, /run: pnpm run format:check/);
+  assert.doesNotMatch(formatWorkflow, /prettier\s+--check/);
+
+  const checks = JSON.parse(
+    fs.readFileSync(path.join(repositoryRoot, 'workflow/checks.json'), 'utf8'),
+  );
+  assert.deepEqual(checks.checks['workflow-format'], {
+    command: [
+      'node-package-bin',
+      '.',
+      'prettier',
+      'prettier',
+      '--check',
+      'packages/workflow-engine',
+      'workflow',
+      'apps/api/src/__tests__/setup/datasource.factory.ts',
+      'apps/api/src/__tests__/setup/database-target-policy.ts',
+      'apps/api/src/__tests__/isolated/database-target-policy.isolated.spec.ts',
+      'package.json',
+      'pnpm-workspace.yaml',
+      'openspec/changes/establish-executable-ai-workflow',
+      'docs/planning/PLAN-EXECUTABLE_AI_WORKFLOW_ENGINE.md',
+      'docs/planning/PLAN-DOCUMENTATION_STRUCTURE_V2.md',
+      'docs/README.md',
+      'docs/ROADMAP.md',
+      'docs/CURRENT_AND_NEXT_STEPS.md',
+      'docs/DOCUMENT_STRUCTURE_GUIDE.md',
+      'AGENTS.md',
+    ],
+    destructiveDatabase: false,
+  });
+});
+
 test('repository exposes only reviewed OpenSpec planning skills', () => {
   const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
   const agentSkillsRoot = path.join(repositoryRoot, '.agents/skills');

--- a/packages/workflow-engine/test/session.integration.test.ts
+++ b/packages/workflow-engine/test/session.integration.test.ts
@@ -10,6 +10,7 @@ import './archive-transition.integration.test.ts';
 import './ci-archive.integration.test.ts';
 
 import { WorkflowError } from '../src/errors.ts';
+import { runRegisteredCheck } from '../src/registered-check.ts';
 import { abortSession, checkSession, startSession } from '../src/session.ts';
 import './atomic-text.test.ts';
 import './completion.integration.test.ts';
@@ -37,6 +38,97 @@ import {
   isWorkflowError,
   runtimeRoot,
 } from './fixture.ts';
+
+test('registered check execution returns pinned non-destructive evidence', () => {
+  const repository = createFixtureRepository();
+  try {
+    const result = runRegisteredCheck(repository, 'fixture', process.env);
+
+    assert.equal(result.head, git(repository, ['rev-parse', 'HEAD']).trim());
+    assert.deepEqual(
+      {
+        checkId: result.check.checkId,
+        outcome: result.check.outcome,
+        exitCode: result.check.exitCode,
+        destructiveDatabase: result.check.destructiveDatabase,
+      },
+      {
+        checkId: 'fixture',
+        outcome: 'passed',
+        exitCode: 0,
+        destructiveDatabase: false,
+      },
+    );
+    assert.match(result.check.runnerDigest, /^[0-9a-f]{64}$/);
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('registered check execution rejects unknown and destructive checks', () => {
+  const repository = createFixtureRepository();
+  try {
+    assert.throws(
+      () => runRegisteredCheck(repository, 'unknown', process.env),
+      (error) => isWorkflowError(error, 'CI_CHECK_UNKNOWN'),
+    );
+
+    configureChecks(
+      repository,
+      {
+        destructive: {
+          command: ['node', 'scripts/pass.mjs'],
+          destructiveDatabase: true,
+        },
+      },
+      ['destructive'],
+    );
+
+    assert.throws(
+      () => runRegisteredCheck(repository, 'destructive', process.env),
+      (error) => isWorkflowError(error, 'STANDALONE_DESTRUCTIVE_CHECK'),
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('registered check execution rejects dirty and mutated checkouts', () => {
+  const dirtyRepository = createFixtureRepository();
+  try {
+    fs.writeFileSync(path.join(dirtyRepository, 'dirty.txt'), 'dirty\n');
+    assert.throws(
+      () => runRegisteredCheck(dirtyRepository, 'fixture', process.env),
+      (error) => isWorkflowError(error, 'STANDALONE_CHECK_DIRTY_WORKTREE'),
+    );
+  } finally {
+    fs.rmSync(dirtyRepository, { recursive: true, force: true });
+  }
+
+  const mutatingRepository = createFixtureRepository();
+  try {
+    configureChecks(
+      mutatingRepository,
+      {
+        mutating: {
+          command: [
+            'node',
+            'scripts/write-file.mjs',
+            path.join(mutatingRepository, 'mutated.txt'),
+          ],
+          destructiveDatabase: false,
+        },
+      },
+      ['mutating'],
+    );
+    assert.throws(
+      () => runRegisteredCheck(mutatingRepository, 'mutating', process.env),
+      (error) => isWorkflowError(error, 'CI_CHECK_MUTATED_WORKTREE'),
+    );
+  } finally {
+    fs.rmSync(mutatingRepository, { recursive: true, force: true });
+  }
+});
 
 test('start rejects protected and dirty repositories without leaving runtime state', () => {
   const repository = createFixtureRepository();


### PR DESCRIPTION
## Summary

- add a clean-checkout workflow adapter for running registered checks by ID
- route the GitHub formatting job through the same workflow-format registry authority used by managed tasks
- keep the historical workflow-format definition and generated artifacts unchanged

## Verification

- pnpm run format:check
- pnpm workflow ci --base 7d37d9ad38d32071d1e3cf1eee5454170780ef75 --head 9fd71ae76bd5cbc428668b5aba48dbbf4fd09526 --json

No API database tests were run; this change only affects workflow governance tooling and documentation.