### PR TITLE
Add break-glass maintainer mode

### DIFF
--- a/.github/workflows/workflow-assurance.yml
+++ b/.github/workflows/workflow-assurance.yml
@@ -1,7 +1,7 @@
 name: Workflow Assurance
 
 on:
-  pull_request:
+  pull_request_target:
 
 permissions:
   contents: read
@@ -16,12 +16,32 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
+      - name: Checkout exact PR base
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: trusted-base
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
       - name: Checkout exact PR head
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
+          path: candidate
           fetch-depth: 0
+          fetch-tags: false
           persist-credentials: false
+
+      - name: Import protected maintainer audit tags
+        working-directory: candidate
+        run: |
+          git for-each-ref --format='delete %(refname)' refs/tags/workflow-grant/ |
+            git update-ref --stdin
+          git fetch --no-tags ../trusted-base/.git \
+            '+refs/tags/workflow-grant/*:refs/tags/workflow-grant/*'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
@@ -34,12 +54,25 @@ jobs:
         with:
           node-version: 22.22.1
           cache: pnpm
+          cache-dependency-path: |
+            trusted-base/pnpm-lock.yaml
+            candidate/pnpm-lock.yaml
 
-      - name: Install locked dependencies
+      - name: Install trusted base dependencies
+        working-directory: trusted-base
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Install candidate dependencies without scripts
+        working-directory: candidate
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Recompute workflow assurance
+        working-directory: candidate
+        env:
+          GH_TOKEN: ''
+          GITHUB_TOKEN: ''
         run: >-
-          pnpm workflow ci
+          node --experimental-strip-types
+          ../trusted-base/packages/workflow-engine/src/cli.ts ci
           --base "${{ github.event.pull_request.base.sha }}"
           --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,11 @@ Only an executable workflow command may authorize a planning commit, task
 completion, controlled-document update, staging, managed commit, or archive.
 Never treat an AI claim, checked box, or prose status as evidence.
 
+Break-glass authority is human-only. An agent may explain the maintainer
+commands or prepare an ordinary reviewed OpenSpec change, but must not attempt
+to satisfy the controlling-terminal, trusted-signer, protected-tag, or remote
+approval requirements on the maintainer's behalf.
+
 ## Planning Skill Routing
 
 The exact supported skill names are listed below. Do not invent aliases from
@@ -81,6 +86,29 @@ edit checkboxes, or commit managed task work by hand.
 Archive is a separate transition. Do not manually move an active OpenSpec
 change or run an upstream archive command directly.
 
+### Human-only break-glass maintenance
+
+These commands are not an alternate task lifecycle. Grant issuance and commit
+creation require the eligible maintainer at a controlling interactive terminal;
+use `docs/WORKFLOW.md` for the complete bootstrap, pilot, sealing, and recovery
+procedure.
+
+| Command | Use when |
+| ------- | -------- |
+| `pnpm workflow maintainer grant ... --json` | A human maintainer is issuing one short-lived, single-use grant for sorted exact eligible authority paths |
+| `pnpm workflow maintainer inspect [grant-id] --json` | Reading redacted local grant, reservation, or terminal state |
+| `pnpm workflow maintainer revoke <grant-id> --json` | Terminally revoking an unused, reserved, or already-terminal grant; repeated use is cleanup-safe |
+| `pnpm workflow authority-start <id> --grant <grant-id> --json` | Reserving the published grant on the exact clean `work/<id>` branch and base |
+| `pnpm workflow authority-check <session-id> --json` | Running all base-pinned normal checks against an exact-path authority diff |
+| `pnpm workflow authority-commit <session-id> --message "Subject" --json` | Creating the signed authority-maintenance commit and consuming the grant from current evidence |
+| `pnpm workflow authority-recover <session-id> --json` | Finalizing only an exact durable commit journal after an interrupted authority commit |
+| `pnpm workflow authority-abort <session-id> --reason "Reason" --json` | Cancelling an active pre-commit authority session and terminally revoking its grant |
+
+Never stage or commit authority work manually, reuse a failed or expired grant,
+delete its audit tag to erase history, or use `authority-recover` as a general
+retry. Until the remote prerequisites in `docs/WORKFLOW.md` are independently
+verified, describe the facility as bootstrap-only, not sealed enforcement.
+
 ### Issues and managed documents
 
 | Command                                          | Use when                                                        |
@@ -121,6 +149,7 @@ Managed commit forms are mutually exclusive:
 | Task    | `Change: <id>` and `Task: <task-id>`             | session lifecycle           |
 | Plan    | `Change: <id>` and `Transition: plan`            | `workflow plan-commit`      |
 | Archive | `Change: <id>` and `Transition: archive`         | `workflow archive`          |
+| Authority | `Change: <id>`, `Transition: authority-maintenance`, and `Grant: <grant-id>` | human-only authority lifecycle |
 
 Do not hand-author or mix these trailers. The exact lifecycle, recovery,
 upgrade, and post-merge pilot procedures are in `docs/WORKFLOW.md`.

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`3.1` — Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
+`4.1` — Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
 
 ## Next Task
 
-`4.1` — Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
+`4.2` — Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
 
 ## Current Focus
 
-Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
+Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -4,19 +4,19 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Change
 
-`refresh-agent-document-governance-v2`
+`add-break-glass-maintainer-mode`
 
 ## Current Task
 
-None — all tasks are complete.
+`1.2` — Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
 
 ## Next Task
 
-None.
+`2.1` — Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
 
 ## Current Focus
 
-Prepare the completed change for explicit archival review.
+Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
 
 ## Known Blockers
 
@@ -26,7 +26,7 @@ Prepare the completed change for explicit archival review.
 ## References
 
 - [Roadmap](ROADMAP.md)
-- [Active change](../openspec/changes/refresh-agent-document-governance-v2/)
-- [Workflow assurance delta](../openspec/changes/refresh-agent-document-governance-v2/specs/workflow-assurance/spec.md)
+- [Active change](../openspec/changes/add-break-glass-maintainer-mode/)
+- [Workflow assurance delta](../openspec/changes/add-break-glass-maintainer-mode/specs/workflow-assurance/spec.md)
 - [Issue log](ISSUE_LOG.md)
 - [System architecture](architecture/ARCHITECTURE.md)

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,7 +8,7 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`5.1` — Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
+None — all tasks are complete.
 
 ## Next Task
 
@@ -16,7 +16,7 @@ None.
 
 ## Current Focus
 
-Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
+Prepare the completed change for explicit archival review.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`4.2` — Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
+`5.1` — Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
 
 ## Next Task
 
-`5.1` — Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
+None.
 
 ## Current Focus
 
-Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
+Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`1.2` — Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
+`2.1` — Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
 
 ## Next Task
 
-`2.1` — Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
+`2.2` — Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
 
 ## Current Focus
 
-Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
+Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`2.1` — Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
+`2.2` — Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
 
 ## Next Task
 
-`2.2` — Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
+`3.1` — Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
 
 ## Current Focus
 
-Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
+Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`2.2` — Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
+`3.1` — Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
 
 ## Next Task
 
-`3.1` — Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
+`4.1` — Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
 
 ## Current Focus
 
-Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
+Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
 
 ## Known Blockers
 

--- a/docs/CURRENT_AND_NEXT_STEPS.md
+++ b/docs/CURRENT_AND_NEXT_STEPS.md
@@ -8,15 +8,15 @@ This generated handoff contains semantic project state only. Its sources are the
 
 ## Current Task
 
-`4.1` — Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
+`4.2` — Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
 
 ## Next Task
 
-`4.2` — Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
+`5.1` — Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
 
 ## Current Focus
 
-Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
+Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
 
 ## Known Blockers
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-_Last verified: July 16, 2026_
+_Last verified: July 17, 2026_
 
 This document owns project priority. Detailed implementation tasks belong only
 in the linked OpenSpec change.
@@ -9,20 +9,33 @@ in the linked OpenSpec change.
 
 ### Finish repository workflow adoption
 
-- Complete and merge `integrate-openspec-with-workflow`, then run the separate
-  maintainer-owned, non-database post-merge pilot in `docs/WORKFLOW.md`. The
-  disposable-repository rehearsal is test evidence, not that pilot.
+- Complete and merge `add-break-glass-maintainer-mode` through the ordinary
+  managed lifecycle; this implementation PR is the bootstrap exception and
+  must not contain or claim an authority-maintenance commit.
+- Keep break-glass maintainer mode explicitly **bootstrap-only** until a human
+  maintainer independently verifies protected `workflow-grant/**` tags, the
+  required base-owned `workflow-assurance` check, no-bypass/up-to-date branch
+  rules, and the protected environment approval for sealing.
+- Run both maintainer-owned, non-database post-merge gates in
+  `docs/WORKFLOW.md`: the ordinary plan/task/archive pilot and the separate
+  break-glass bootstrap pilot. Disposable-repository and interrupted-commit
+  rehearsals are test evidence, not the real pilots.
 - Keep support undeclared until the pilot proves plan, task, archive,
-  idempotency, repository-local Codex discovery observation, and real
-  `workflow-assurance` replay from the configured base.
+  authority grant/revoke/expiry/cleanup, idempotent recovery, repository-local
+  Codex discovery observation, protected audit-tag publication, and real
+  base-owned `workflow-assurance` replay from the configured base.
+- Confirm or rotate to a human-presence hardware signer while still in
+  bootstrap, then use a separately approved old-key-authorized authority commit
+  for the one-way `bootstrap` → `sealed` transition. Lost-key or immutable
+  trust-root recovery remains repository-admin and out-of-band.
 - Keep the retained root Spectra configuration historical-only; keep
   Spectra-generated agent skills removed and every Spectra command, adapter,
   and lifecycle state outside all execution paths.
-- Activate the remote GitHub ruleset only after the workflow is present on the
-  default branch: require pull requests, `workflow-assurance`, an up-to-date
-  base, and no bypass. Require code-owner approval with stale-review dismissal
-  only when at least two independent eligible human maintainers exist
-  (`ISS-003`).
+- Activate the remote GitHub ruleset only after the base-owned workflow is
+  present on the default branch: require pull requests,
+  `workflow-assurance`, an up-to-date base, and no bypass. Require code-owner
+  approval with stale-review dismissal only when at least two independent
+  eligible human maintainers exist (`ISS-003`).
 - Complete the approved `refresh-agent-document-governance-v2` managed change to
   move noncanonical legacy documents into the immutable archive and update
   current references.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -1,6 +1,6 @@
 # Repository Workflow
 
-_Last reviewed: July 16, 2026_
+_Last reviewed: July 17, 2026_
 
 This repository plans changes with OpenSpec and executes them with the
 repository-owned `pnpm workflow` engine. Spectra is retained only for
@@ -25,11 +25,12 @@ current evidence.
 
 ## Managed Transition Matrix
 
-| Kind    | Exact trailers                           | Public authority                          |
-| ------- | ---------------------------------------- | ----------------------------------------- |
-| Task    | `Change: <id>` and `Task: <task-id>`     | session `complete-task`/`finish`/`commit` |
-| Plan    | `Change: <id>` and `Transition: plan`    | `pnpm workflow plan-commit <id>`          |
-| Archive | `Change: <id>` and `Transition: archive` | `pnpm workflow archive <id>`              |
+| Kind      | Exact trailers                                                               | Public authority                          |
+| --------- | ---------------------------------------------------------------------------- | ----------------------------------------- |
+| Task      | `Change: <id>` and `Task: <task-id>`                                         | session `complete-task`/`finish`/`commit` |
+| Plan      | `Change: <id>` and `Transition: plan`                                        | `pnpm workflow plan-commit <id>`          |
+| Archive   | `Change: <id>` and `Transition: archive`                                     | `pnpm workflow archive <id>`              |
+| Authority | `Change: <id>`, `Transition: authority-maintenance`, and `Grant: <grant-id>` | human-only authority lifecycle            |
 
 The forms are mutually exclusive. A plan or archive commit has no `Task:`
 trailer, a task commit has no `Transition:` trailer, and none may be mixed with
@@ -228,6 +229,159 @@ approval with stale-review dismissal is additionally required only when at
 least two independent eligible human maintainers exist. Until those remote
 rules are configured, local and workflow-file enforcement must not be described
 as merge authority.
+
+## Break-Glass Maintainer Mode
+
+Break-glass maintenance is a human-only fourth commit kind for changing exact
+workflow authority files when the ordinary task lifecycle must remain closed.
+It is not a bypass for product code, ordinary documents, failed checks, task
+completion, plan commits, or archives. The engine keeps local grants,
+reservations, terminal records, sessions, and commit journals in the Git common
+directory shared by linked worktrees; none is a reusable worktree credential.
+
+The checked-in implementation starts in `bootstrap`. Describe it as
+**bootstrap-only**, and do not claim sealed enforcement, until a maintainer has
+independently verified every remote prerequisite below:
+
+- protect the `workflow-grant/**` tag namespace against creation, update, and
+  deletion by unapproved actors while retaining administrator audit recovery;
+- require pull requests, an up-to-date base, the real `workflow-assurance`
+  check, and no bypass on the configured protected branch;
+- configure and verify the protected environment/approval gate that will be
+  required before the sealing PR can merge; and
+- retain the signed, non-secret audit envelope outside the local grant store so
+  a repository administrator can investigate a deleted or disputed remote tag.
+
+A checked-in workflow, a local hook, or a successful local replay does not
+prove any of these GitHub settings. The implementation PR is the one bootstrap
+exception: its base does not contain the verifier, so it remains an ordinary
+managed change. After that PR merges, `pull_request_target` loads the exact base
+workflow and trust material, checks the candidate separately without persisted
+credentials, and imports only the base repository's protected grant tags.
+
+### Human signer and repository prerequisites
+
+Perform grant issuance and authority commit creation directly from a
+controlling interactive terminal. Redirected or unattended use is rejected.
+The exact base policy must trust the configured key. Use a passphrase-encrypted
+SSH private key or a human-presence FIDO `*-sk` key; an unencrypted software
+key, SSH agent, askpass program, environment force switch, or candidate-added
+key cannot create authority.
+
+Configure the repository-local Git signer before issuing a grant:
+
+```bash
+git config --local gpg.format ssh
+git config --local user.signingkey ~/.ssh/<trusted-maintainer-key>
+```
+
+`user.signingkey` must resolve to an absolute regular file (a `~/` path is
+accepted), its fingerprint must match a signer in the exact base
+`workflow/maintainer-policy.json`, and normal Git author name/email must also be
+configured. Keep the worktree clean, use the canonical origin, and create an
+ordinary reviewed OpenSpec change plus planning commit on the exact
+`work/<change-id>` branch before issuing authority.
+
+### Maintainer command reference
+
+| Command                                                                                                                                             | Use and boundary                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm workflow maintainer grant --change <id> --paths <exact-path> [--paths <exact-path> ...] --reason <text> [--ttl <minutes>m] [--uses 1] --json` | Interactively sign one grant bound to the current full base commit, base policy blob, repository, change, sorted exact eligible paths, reason, signer, expiry, and one use. The default and maximum TTL are 30 minutes.                             |
+| `pnpm workflow maintainer inspect [grant-id] --json`                                                                                                | Read redacted available, reserved, consumed, or revoked local state. It grants no authority and exposes no private signing material.                                                                                                                |
+| `pnpm workflow maintainer revoke <grant-id> --json`                                                                                                 | Terminally revoke an available or reserved grant. Repeating it is cleanup-safe; a consumed or revoked grant never becomes available again.                                                                                                          |
+| `pnpm workflow authority-start <change-id> --grant <grant-id> --json`                                                                               | Atomically reserve the grant on its exact clean base and `work/<change-id>` branch, then pin policy, contract, signer, exact paths, and the complete normal check set.                                                                              |
+| `pnpm workflow authority-check <session-id> --json`                                                                                                 | Require at least one changed granted path, reject every ungranted path, run all base-pinned normal checks, and record current content-addressed evidence. Any later edit makes it stale.                                                            |
+| `pnpm workflow authority-commit <session-id> --message "Imperative subject" --json`                                                                 | Revalidate human presence and the same signer, stage only the exact diff, create one SSH-signed authority-maintenance commit with engine-owned trailers, advance the ref, and consume the grant. There is no authority `complete-task` or `finish`. |
+| `pnpm workflow authority-recover <session-id> --json`                                                                                               | Resume only a durable authority-commit journal. It may complete the exact pending old-OID ref update or idempotent consumption; ambiguity terminally revokes the use.                                                                               |
+| `pnpm workflow authority-abort <session-id> --reason "Concrete reason" --json`                                                                      | Cancel an active session before commit journaling and terminally revoke the reservation. It does not discard or reset worktree edits.                                                                                                               |
+
+Grant issuance creates both the local single-use token and an annotated audit
+tag. Run the exact `publishCommand` returned by the command immediately; it has
+this form:
+
+```bash
+git push origin refs/tags/workflow-grant/<grant-id>:refs/tags/workflow-grant/<grant-id>
+```
+
+Do not delete or replace the tag after revocation, failure, expiry, or
+consumption. The envelope is non-secret audit evidence, and CI requires the
+exact protected tag. Do not extend, copy, or reuse an expired grant; issue a
+new grant from the new exact base.
+
+### Authority execution sequence
+
+Use one grant for one authority commit:
+
+```bash
+pnpm workflow maintainer grant --change <change-id> \
+  --paths <exact-authority-path> --reason "Reviewed reason" --json
+git push origin refs/tags/workflow-grant/<grant-id>:refs/tags/workflow-grant/<grant-id>
+pnpm workflow maintainer inspect <grant-id> --json
+pnpm workflow authority-start <change-id> --grant <grant-id> --json
+# Edit at least one and only the exact granted paths.
+pnpm workflow authority-check <session-id> --json
+pnpm workflow authority-commit <session-id> \
+  --message "Imperative authority subject" --json
+pnpm workflow maintainer inspect <grant-id> --json
+```
+
+Push the branch, open a PR, and require the base-owned
+`workflow-assurance` result. CI verifies the grant and commit signatures, audit
+tag, parent/base, policy blob, repository identity, expiry both at commit time
+and PR evaluation time, exact diff, single claim across the PR range, phase
+transition, and every normal check. If CI queues past expiry, issue a new grant
+and new isolated authority commit; never amend, replay, or relax the old one.
+
+Any failure after reservation closes the session and terminally revokes that
+use. `authority-abort` is for an active session that has not started commit
+journaling. `authority-recover` is only for a journal created by
+`authority-commit`; it is not a retry for a failed check, expired grant, dirty
+branch, missing tag, signature error, or divergent tree. Preserve the error,
+inspect the session and grant, and obtain explicit maintainer approval before
+discarding any leftover edits. A lost trusted key, missing/altered journal,
+divergent branch, or damaged trust root is a repository-admin, out-of-band
+recovery event with separately retained audit evidence—not a workflow command
+or AI-accessible override.
+
+### Bootstrap pilot and one-way sealing
+
+After this implementation is merged, first verify the remote prerequisites and
+run a dedicated, non-database bootstrap pilot from the updated configured base:
+
+1. Create and plan-commit a small OpenSpec change for one harmless exact file
+   already allowed by `bootstrapEligiblePaths`. Do not put product work or the
+   phase transition in this pilot.
+2. With separate grants, record read-only inspection, idempotent explicit
+   revocation, a one-minute expiry rejection, and terminal cleanup after a
+   deliberate pre-commit failure. Never reuse those grant IDs or delete their
+   audit tags.
+3. Issue and publish a fresh grant for the successful pilot, run the full
+   authority sequence, then call `authority-recover` on the consumed session to
+   prove idempotent journal finalization. Interrupted commit points remain
+   integration-test evidence; do not deliberately crash or corrupt a real
+   repository.
+4. Push the pilot PR and record the exact commands, semantic change/grant IDs,
+   audit-tag publication, check results, commit-signature verification, and
+   base-owned `workflow-assurance` result. Merge only through the configured
+   remote rules.
+5. Confirm or rotate to a human-presence hardware signer while the parent
+   policy is still in bootstrap. A new signer is trusted only after an
+   old-key-authorized authority commit merges.
+
+Only after that evidence and protected-environment approval may a separate
+authority-maintenance change set `phase` from `bootstrap` to `sealed`. The
+grant must be signed by a signer trusted in the parent policy and must target
+the exact policy file. The transition is one-way: CI rejects
+`sealed` → `bootstrap`, removal of immutable paths or required checks, and any
+sealed grant that targets the verifier, policy/signer loader, policy itself, or
+other `sealedImmutablePaths`. Review the sealed path list before the transition
+because later maintenance of those paths requires repository-admin,
+out-of-band recovery; there is no force flag.
+
+Before sealing, rollback means a separately reviewed ordinary managed revert
+of this integration. After sealing, ordinary eligible non-immutable authority
+paths may still use a valid old-policy grant, but the immutable trust root
+cannot be rolled back through maintainer mode.
 
 ### Standalone registered checks
 

--- a/openspec/changes/add-break-glass-maintainer-mode/.openspec.yaml
+++ b/openspec/changes/add-break-glass-maintainer-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: expense-app
+created: 2026-07-16

--- a/openspec/changes/add-break-glass-maintainer-mode/design.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/design.md
@@ -1,0 +1,217 @@
+## Context
+
+The workflow engine deliberately anchors existing policy and rejects ordinary
+task edits that would redefine their own authority. That is correct for routine
+work but leaves no governed bootstrap or emergency path. The local boundary is
+the Git common directory shared by all linked worktrees; the remote boundary is
+GitHub CI evaluating an untrusted candidate tree against the merge-base.
+
+This change installs the mechanism through ordinary reviewed task commits. It
+does not use its own break-glass path during bootstrap. After merge, every
+authority-maintenance commit is evaluated by the engine and trust policy from
+its parent/base, while the pull-request job runs the verifier from the trusted
+base checkout. Candidate changes therefore cannot authorize themselves.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Require a fresh human-present SSH signature for one exact authority change.
+- Bind grants to a stable repository identity, canonical remote, full base
+  commit, change ID, exact paths, reason, expiry, and one use.
+- Share reservation and consumption state safely across linked worktrees.
+- Preserve every existing schema, path, runner, document, secret, database,
+  branch, and CI check.
+- Produce a signed fourth managed commit kind and verify it independently in
+  CI using only parent/base trust material.
+- Provide fail-closed recovery, explicit revocation, replay detection, key
+  rotation, and an auditable one-way bootstrap-to-sealed transition.
+
+**Non-Goals:**
+
+- No product, API, mobile, web, or database behavior.
+- No unattended signer, environment bypass, force flag, repository boolean,
+  broad grant glob, multi-use v1 grant, or ordinary task escape hatch.
+- No automatic push, merge, GitHub ruleset mutation, or repository-admin
+  recovery automation.
+
+## Decisions
+
+### 1. Use a versioned trusted-base policy and SSH signatures
+
+`workflow/maintainer-policy.json` is schema validated and contains the stable
+GitHub repository identifier, canonical origin, phase, eligible bootstrap
+paths, immutable sealed paths, trusted signer identities/public keys, SSH
+signature namespaces, audit-tag prefix, and required check IDs. The first
+version trusts the existing `tomchen86` ED25519 public key.
+
+Every authority operation pins the policy blob from the grant base commit.
+CI loads that same policy from the authority commit's parent. A candidate
+policy can become effective only after a valid old-policy-authorized commit is
+merged. In sealed phase, immutable verifier and trust-loader paths are denied
+even when named by a grant. A key rotation is therefore an old-key-signed
+policy change; a candidate key cannot trust itself.
+
+SSH was chosen because OpenSSH is already available and supplies detached data
+signing plus Git commit signing without another runtime dependency. The
+production provider resolves the configured signing-key file, removes agent
+and askpass variables, requires controlling input/output TTYs, and accepts only
+a FIDO/security-key signer or an encrypted private key that must prompt on the
+controlling terminal. An unencrypted software key and a non-TTY process are
+rejected before a grant is written. Tests inject an in-process provider only
+at the module boundary; no CLI or environment flag exposes that injection.
+
+### 2. Canonicalize and sign the complete grant envelope
+
+The v1 payload has a fixed field order and UTF-8/LF serialization. It includes
+`version`, UUID `grantId`, policy-derived repository identity and origin, full
+base OID, change ID, sorted unique exact paths, issued/expiry timestamps,
+`maxUses: 1`, bounded reason, signer identity, and the parent policy blob OID.
+The detached SSH signature covers the complete payload under a dedicated
+namespace. Verification reconstructs the canonical bytes and rejects unknown
+fields, altered order-independent JSON values, clock reversal, TTL over 30
+minutes, non-one use, or an untrusted signer.
+
+Grant paths must be repository-relative tracked regular files eligible under
+the parent policy. Path validation rejects absolute paths, traversal, control
+characters, backslashes, glob syntax, directories, symlink segments, missing
+files, exact-case mismatches, and case-fold collisions. Eligibility policy may
+use reviewed directory prefixes, but a signed grant never does.
+
+### 3. Keep bearer state local and publish only a signed audit envelope
+
+Available tokens, reservations, terminal consumed/revoked records, and commit
+journals live below
+`<git-common-dir>/workflow-engine/maintainer-grants/` with `0700` directories,
+`0600` files, atomic write/rename/fsync, and the existing repository lifecycle
+lock. No token appears in the worktree or commit.
+
+Grant issuance also creates an immutable annotated audit tag at
+`refs/tags/workflow-grant/<grant-id>` whose message is exactly the signed,
+non-secret envelope. The command does not push; it reports the exact tag ref
+that the maintainer must publish. GitHub must protect that tag namespace. CI
+fetches the exact tag, verifies its envelope signature against parent policy,
+and does not treat the tag object's own metadata or candidate files as trust.
+This provides a portable protected audit store without a reusable bearer
+token or candidate-controlled secret.
+
+### 4. Use a separate authority state machine
+
+`authority-start` validates the clean `work/<change-id>` branch, exact HEAD,
+policy, audit tag, signature, time, change contract, exact paths, and absence of
+other lifecycle work, then atomically moves the local grant from available to
+reserved and writes an authority session pinned to all inputs.
+
+`authority-check` revalidates the reservation, base, policy, exact changed
+paths, signer, expiry, and repository projection. It runs the union of normal
+policy-required checks and every check required by the active OpenSpec change.
+It writes content-addressed evidence but never completes task checkboxes.
+
+`authority-commit` requires current evidence, at least one granted path changed,
+no other path, an unchanged index, and a still-valid reservation. It creates a
+signed commit through Git plumbing with exactly:
+
+```text
+Change: <change-id>
+Transition: authority-maintenance
+Grant: <grant-id>
+```
+
+The form is mutually exclusive with `Task`, `plan`, and `archive`. The change's
+ordinary tasks are not completed by this transition; the change must describe
+the authority work and may be archived only after its separately defined
+completion policy is satisfied.
+
+Any start/check/commit failure after reservation terminally revokes that use,
+closes the session, and releases locks. `maintainer revoke` is idempotent;
+`maintainer inspect` is read-only and redacts local filesystem secrets.
+
+### 5. Journal commit creation before compare-and-swap ref update
+
+Before commit creation, the engine writes and fsyncs a journal containing the
+grant, session, base, expected tree, message digest, and state `preparing`.
+After `git commit-tree` returns the signed commit OID, the journal advances to
+`commit-created`, then the engine performs `git update-ref` with the exact old
+HEAD. After ref success it advances to `ref-updated`, writes the terminal
+consumed record, deletes the reservation/token, and closes the session.
+
+Recovery never makes a grant available again. It verifies journal content,
+commit signature, parent, tree, trailers, and current ref. A matching created
+commit can receive the one pending compare-and-swap; a matching updated ref is
+finalized as consumed; every ambiguous or divergent state is revoked and
+requires a new grant. Repeated cleanup is idempotent.
+
+### 6. Run authority verification from the pull-request base
+
+The assurance workflow moves to `pull_request_target` with read-only contents,
+checks out the candidate SHA without credentials, and separately checks out
+the exact base SHA. It installs locked dependencies without scripts and invokes
+the base engine against the candidate repository. The base verifier parses the
+candidate Git objects but loads maintainer policy, trusted keys, immutable
+paths, and authority verification code from the parent/base checkout.
+
+For each authority commit, CI verifies one parent equal to the grant base,
+canonical trailers, commit SSH signature, grant envelope signature and tag,
+repository identity, policy blob, expiry at commit and current PR evaluation,
+exact diff, unique grant claim across the range, phase transition, and complete
+normal check set. Mixed or duplicate claims fail closed. Ordinary task, plan,
+and archive semantics remain unchanged.
+
+The implementation PR is the one bootstrap exception: because its base has no
+maintainer policy or base verifier, it remains an ordinary managed change under
+the existing `pull_request` assurance. Once merged, the base-owned
+`pull_request_target` definition governs later PRs.
+
+### 7. Seal through an old-key-authorized authority commit
+
+Bootstrap policy permits exact grants for reviewed workflow JSON/schema files
+and engine authority code. Sealing is a normal authority-maintenance commit
+that changes `phase` from `bootstrap` to `sealed`, is signed by an existing
+trusted key, and passes a GitHub protected-environment approval. Reversion to
+bootstrap is always invalid. In sealed mode, verifier, policy loader, signer
+loader, and immutable-path enforcement files cannot be granted. Lost-key
+recovery remains a repository-admin, out-of-band event with separately retained
+audit evidence.
+
+## Risks / Trade-offs
+
+- **[Bootstrap cannot prove itself with code that does not yet exist]** → The
+  implementation PR contains no authority commit and uses the existing managed
+  lifecycle; base-owned verification starts only after merge.
+- **[A normal ED25519 key might be usable without human presence]** → Reject
+  unencrypted software keys, clear SSH agent/askpass paths, and require a TTY;
+  prefer a FIDO `*-sk` key before sealing.
+- **[Audit tags can be deleted by a repository administrator]** → Require a
+  protected tag namespace, preserve the envelope externally for incident
+  review, and treat admin bypass as the final recovery authority.
+- **[A 30-minute grant can expire while CI queues]** → CI fails closed; issue a
+  new grant and isolated authority commit rather than extending or replaying
+  the old grant.
+- **[Base-engine execution constrains future verifier evolution]** → Upgrade in
+  one valid authority commit under the previous verifier; new behavior becomes
+  active only after merge.
+- **[Crash recovery is filesystem- and Git-dependent]** → Use common-directory
+  locking, atomic renames, fsync, exact old-OID ref updates, and terminal
+  revocation for every ambiguous state.
+
+## Migration Plan
+
+1. Merge this ordinary managed change with the bootstrap policy and trusted
+   public key; do not issue an authority grant inside the same PR.
+2. Protect `workflow-grant/**` tags and configure the sealed approval
+   environment in GitHub.
+3. Run a non-destructive bootstrap pilot against one exact authority file,
+   including revocation, expiry, failure cleanup, CI, and recovery evidence.
+4. Rotate to or confirm a hardware-backed signer if the bootstrap key is not
+   human-presence-bound.
+5. Create and merge an authority commit changing the phase to `sealed` after
+   protected-environment approval.
+6. Rollback before sealing by reverting the implementation through the normal
+   managed workflow. After sealing, rollback requires a valid old-policy grant
+   and cannot remove immutable trust-root enforcement.
+
+## Open Questions
+
+None for implementation. GitHub tag protection and protected-environment
+activation are maintainer-owned post-merge operations and remain explicit
+pilot evidence rather than repository claims.

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -1,0 +1,141 @@
+{
+  "schemaVersion": 1,
+  "changeId": "add-break-glass-maintainer-mode",
+  "tasks": {
+    "1.1": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/maintainer-grant.ts",
+        "packages/workflow-engine/src/maintainer-policy.ts",
+        "packages/workflow-engine/src/paths.ts",
+        "packages/workflow-engine/test/contracts.test.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts",
+        "packages/workflow-engine/test/session.integration.test.ts",
+        "workflow/maintainer-policy.json",
+        "workflow/schemas/maintainer-grant.schema.json",
+        "workflow/schemas/maintainer-policy.schema.json"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "1.2": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/git.ts",
+        "packages/workflow-engine/src/maintainer-grant.ts",
+        "packages/workflow-engine/src/maintainer-signer.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "2.1": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/maintainer-store.ts",
+        "packages/workflow-engine/src/planning-lock.ts",
+        "packages/workflow-engine/src/session-store.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "2.2": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/check-runner.ts",
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/maintainer-report.ts",
+        "packages/workflow-engine/src/maintainer-session.ts",
+        "packages/workflow-engine/src/maintainer-store.ts",
+        "packages/workflow-engine/src/report-store.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "3.1": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/git-transitions.ts",
+        "packages/workflow-engine/src/hooks.ts",
+        "packages/workflow-engine/src/maintainer-commit.ts",
+        "packages/workflow-engine/src/maintainer-recovery.ts",
+        "packages/workflow-engine/src/maintainer-store.ts",
+        "packages/workflow-engine/src/managed-trailers.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts",
+        "packages/workflow-engine/test/managed-trailers.contract.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "4.1": {
+      "allowedPaths": [
+        "packages/workflow-engine/src/ci-authority.ts",
+        "packages/workflow-engine/src/ci-commit-validation.ts",
+        "packages/workflow-engine/src/ci-git.ts",
+        "packages/workflow-engine/src/ci-sequence.ts",
+        "packages/workflow-engine/src/ci.ts",
+        "packages/workflow-engine/src/maintainer-grant.ts",
+        "packages/workflow-engine/src/maintainer-policy.ts",
+        "packages/workflow-engine/src/managed-trailers.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "4.2": {
+      "allowedPaths": [
+        ".github/workflows/workflow-assurance.yml",
+        "packages/workflow-engine/src/ci.ts",
+        "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/git.ts",
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format"
+      ]
+    },
+    "5.1": {
+      "allowedPaths": [
+        "AGENTS.md",
+        "docs/CURRENT_AND_NEXT_STEPS.md",
+        "docs/ROADMAP.md",
+        "docs/WORKFLOW.md",
+        "packages/workflow-engine/test/contracts.test.ts"
+      ],
+      "requiredChecks": [
+        "workflow-tests",
+        "workflow-typecheck",
+        "workflow-lint",
+        "workflow-format",
+        "managed-documents"
+      ]
+    }
+  }
+}

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -73,6 +73,7 @@
     },
     "3.1": {
       "allowedPaths": [
+        "packages/workflow-engine/src/ci-sequence.ts",
         "packages/workflow-engine/src/cli.ts",
         "packages/workflow-engine/src/git-transitions.ts",
         "packages/workflow-engine/src/hooks.ts",

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -61,7 +61,8 @@
         "packages/workflow-engine/src/maintainer-session.ts",
         "packages/workflow-engine/src/maintainer-store.ts",
         "packages/workflow-engine/src/report-store.ts",
-        "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
+        "packages/workflow-engine/test/maintainer-mode.integration.test.ts",
+        "workflow/schemas/report.schema.json"
       ],
       "requiredChecks": [
         "workflow-tests",
@@ -77,6 +78,8 @@
         "packages/workflow-engine/src/hooks.ts",
         "packages/workflow-engine/src/maintainer-commit.ts",
         "packages/workflow-engine/src/maintainer-recovery.ts",
+        "packages/workflow-engine/src/maintainer-report.ts",
+        "packages/workflow-engine/src/maintainer-session.ts",
         "packages/workflow-engine/src/maintainer-store.ts",
         "packages/workflow-engine/src/managed-trailers.ts",
         "packages/workflow-engine/test/maintainer-mode.integration.test.ts",

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -118,6 +118,7 @@
         "packages/workflow-engine/src/ci.ts",
         "packages/workflow-engine/src/cli.ts",
         "packages/workflow-engine/src/git.ts",
+        "packages/workflow-engine/test/ci.integration.test.ts",
         "packages/workflow-engine/test/maintainer-mode.integration.test.ts"
       ],
       "requiredChecks": [

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -40,6 +40,7 @@
     "2.1": {
       "allowedPaths": [
         "packages/workflow-engine/src/cli.ts",
+        "packages/workflow-engine/src/maintainer-grant.ts",
         "packages/workflow-engine/src/maintainer-store.ts",
         "packages/workflow-engine/src/planning-lock.ts",
         "packages/workflow-engine/src/session-store.ts",

--- a/openspec/changes/add-break-glass-maintainer-mode/guard.json
+++ b/openspec/changes/add-break-glass-maintainer-mode/guard.json
@@ -4,6 +4,7 @@
   "tasks": {
     "1.1": {
       "allowedPaths": [
+        "packages/workflow-engine/src/contract-artifacts.ts",
         "packages/workflow-engine/src/maintainer-grant.ts",
         "packages/workflow-engine/src/maintainer-policy.ts",
         "packages/workflow-engine/src/paths.ts",

--- a/openspec/changes/add-break-glass-maintainer-mode/proposal.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+The repository workflow currently fails closed when established authority files
+must change, but it has no governed recovery path other than repository-admin
+intervention. The roadmap's "Finish repository workflow adoption" work needs a
+human-only, auditable break-glass transition before the workflow can be piloted
+and sealed without introducing an AI-accessible bypass.
+
+## What Changes
+
+- Add a closed-by-default maintainer grant model bound to the repository,
+  exact base commit, OpenSpec change, exact eligible paths, expiry, use count,
+  reason, signer, and canonical signature.
+- Add interactive SSH-backed grant issuance plus inspect and revoke operations;
+  keep grants, reservations, and recovery journals in the Git common directory.
+- Add isolated `authority-start`, `authority-check`, and `authority-commit`
+  transitions that preserve every ordinary safety check and emit one signed
+  `authority-maintenance` commit.
+- Extend managed-trailer and CI replay contracts so authority commits are
+  independently validated against trust material loaded from the merge-base,
+  never from candidate policy.
+- Add bootstrap and sealed phases, including immutable trust-root paths and
+  old-key-authorized key rotation.
+- Document operator use, recovery, CI audit-envelope handling, and the explicit
+  one-way sealing transition.
+- Exclude product behavior, database operations, ordinary task bypasses,
+  unattended grant issuance, broad path globs, and any environment-variable or
+  repository-controlled force switch.
+
+## Capabilities
+
+### New Capabilities
+
+- `break-glass-maintainer-mode`: Human-interactive grant issuance, authority
+  session isolation, signed commit creation, independent CI verification,
+  revocation, replay resistance, recovery, and trust-root sealing.
+
+### Modified Capabilities
+
+- `repository-governance`: Add the fourth managed commit kind and require
+  trusted-base validation for break-glass changes without weakening normal
+  checks or branch assurance.
+
+## Impact
+
+The change affects the TypeScript workflow engine and its integration tests,
+workflow schemas and trust policy, GitHub workflow-assurance execution,
+managed trailer parsing, repository documentation, and agent command routing.
+It adds no product API, mobile, web, database, or runtime dependency behavior.

--- a/openspec/changes/add-break-glass-maintainer-mode/specs/break-glass-maintainer-mode/spec.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/specs/break-glass-maintainer-mode/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Human-present grant issuance
+The workflow engine SHALL keep maintainer mode closed by default and SHALL
+issue a grant only from a controlling interactive terminal through a trusted
+SSH signer that requires human presence.
+
+#### Scenario: Non-interactive issuance is rejected
+- **WHEN** grant issuance lacks a controlling input or output TTY
+- **THEN** the engine rejects the request before signing or writing grant state
+
+#### Scenario: Unattended signer is rejected
+- **WHEN** the configured software key can sign without an interactive secret or the request attempts to use an SSH agent, askpass program, environment bypass, or force option
+- **THEN** the engine rejects the request and creates no grant
+
+#### Scenario: Human-present issuance succeeds
+- **WHEN** a trusted encrypted SSH key or human-presence hardware key signs a valid canonical grant from an interactive terminal
+- **THEN** the engine stores one local available token and creates one signed non-secret audit envelope
+
+### Requirement: Canonical single-purpose grant
+Every grant SHALL use a versioned canonical signed payload bound to the trusted
+policy, stable repository identity, canonical origin, full base commit, OpenSpec
+change, sorted unique exact paths, issue and expiry times, one use, reason, and
+trusted signer identity.
+
+#### Scenario: Default grant bounds are narrow
+- **WHEN** a maintainer omits TTL and use-count options
+- **THEN** the engine issues a grant valid for no more than 30 minutes and exactly one use
+
+#### Scenario: Altered authorization is rejected
+- **WHEN** any signed authorization field, schema version, policy blob, signature, repository, base, change, path, time, reason, use count, or signer differs from the trusted canonical payload
+- **THEN** the engine rejects the grant
+
+#### Scenario: Unsafe grant path is rejected
+- **WHEN** a path is absolute, traversing, globbed, a directory, missing, untracked, symlinked, case-ambiguous, non-exact-case, or outside bootstrap eligibility
+- **THEN** the engine refuses to issue or reserve the grant
+
+### Requirement: Git-common-directory grant state
+The engine MUST keep available tokens, reservations, terminal records, and
+recovery journals in the Git common directory with restrictive permissions and
+atomic persistence shared by all linked worktrees.
+
+#### Scenario: Concurrent worktrees compete for one grant
+- **WHEN** two worktrees attempt to reserve the same available grant
+- **THEN** exactly one reservation succeeds and the other fails without obtaining authority
+
+#### Scenario: Worktree contains no bearer token
+- **WHEN** a grant is issued, reserved, consumed, revoked, or recovered
+- **THEN** no reusable grant or reservation token is written to or committed from the worktree
+
+### Requirement: Protected audit envelope
+Grant issuance SHALL create an immutable namespaced Git audit tag containing
+the signed non-secret envelope, and authority CI SHALL require that exact tag
+and verify it against parent/base trust material.
+
+#### Scenario: Missing or different audit tag is rejected
+- **WHEN** CI cannot resolve the exact grant tag or its envelope differs from the locally claimed grant
+- **THEN** the authority commit fails verification
+
+#### Scenario: Candidate key cannot validate its own envelope
+- **WHEN** a candidate branch adds or changes a signer while claiming an authority grant
+- **THEN** CI verifies the envelope only with signers trusted by the authority commit parent
+
+### Requirement: Isolated authority session
+The engine SHALL expose `authority-start`, `authority-check`, and
+`authority-commit` as a state machine separate from ordinary task, plan, and
+archive transitions.
+
+#### Scenario: Start reserves a valid grant
+- **WHEN** a clean eligible branch at the exact grant base starts the matching change with the matching audit envelope and no lifecycle conflict
+- **THEN** the engine atomically reserves the grant and pins the repository, policy, contract, paths, signer, and checks in an authority session
+
+#### Scenario: Authority check preserves normal checks
+- **WHEN** an active authority session has changes only to exact granted paths
+- **THEN** the engine runs every normally required schema, lint, test, document, secret, safety, and non-destructive database-policy check and records content-addressed evidence
+
+#### Scenario: Failed operation closes authority
+- **WHEN** start after reservation, check, commit, cancellation, expiry, signature validation, base validation, path validation, or lock validation fails
+- **THEN** the session closes, the reservation becomes terminally revoked or consumed, and the grant cannot become available again
+
+### Requirement: Exact authority commit isolation
+`authority-commit` MUST create one signed commit with exactly the granted
+authority diff and canonical mutually exclusive `Change`,
+`Transition: authority-maintenance`, and `Grant` trailers.
+
+#### Scenario: Exact authority commit succeeds
+- **WHEN** at least one granted file changed, no ungranted path changed, current evidence passes, HEAD remains the grant base, and the trusted signer signs the commit
+- **THEN** the engine atomically advances the branch to one authority-maintenance commit and consumes the grant
+
+#### Scenario: Mixed work is rejected
+- **WHEN** the diff contains product code, ordinary documentation, task completion, generated files, or any path absent from the exact grant
+- **THEN** the engine rejects the commit and terminally closes that grant use
+
+#### Scenario: Managed trailer forms are mixed
+- **WHEN** an authority commit also contains `Task`, `plan`, `archive`, another transition, or a non-canonical reserved trailer
+- **THEN** local hooks and CI reject the commit
+
+### Requirement: Fail-closed commit recovery
+Authority commit creation and grant consumption MUST be one recoverable logical
+operation with durable journal states and exact compare-and-swap ref updates.
+
+#### Scenario: Crash occurs after commit object creation
+- **WHEN** recovery finds a valid signed commit object journaled for the still-exact base but the branch ref was not updated
+- **THEN** recovery may perform the one pending exact-old-OID ref update and then consume the grant
+
+#### Scenario: Crash occurs after ref update
+- **WHEN** recovery proves the branch points to the exact journaled valid commit
+- **THEN** recovery idempotently records consumption and never reactivates the grant
+
+#### Scenario: Recovery state is ambiguous
+- **WHEN** the journal, branch, commit, signature, tree, base, or reservation does not match exactly
+- **THEN** recovery revokes the use and refuses to create or accept another commit
+
+### Requirement: Revocation and replay resistance
+The engine SHALL provide read-only inspection and idempotent explicit
+revocation, and SHALL reject expired, revoked, consumed, reserved-by-other,
+previously committed, or duplicate grants.
+
+#### Scenario: Revoke is repeated
+- **WHEN** the maintainer revokes the same available, reserved, revoked, or consumed grant more than once
+- **THEN** cleanup remains safe and the grant never returns to available state
+
+#### Scenario: Grant is claimed twice
+- **WHEN** local state or a pull-request range claims one grant for more than one session or commit
+- **THEN** the engine rejects every duplicate use
+
+### Requirement: Bootstrap and sealed trust phases
+The trusted maintainer policy SHALL begin in bootstrap and SHALL permit only a
+one-way, old-key-authorized transition to sealed mode with immutable verifier
+and trust-root paths.
+
+#### Scenario: Bootstrap grant targets eligible authority
+- **WHEN** a valid bootstrap grant lists exact files under reviewed eligible authority paths and none under immutable paths
+- **THEN** the authority session may modify only those exact files while preserving all checks
+
+#### Scenario: Sealed grant targets immutable trust root
+- **WHEN** a grant in sealed phase includes the verifier, trusted-key loader, policy loader, or immutable-path enforcement
+- **THEN** issuance, local execution, and CI all reject it using parent/base policy
+
+#### Scenario: Phase rollback is attempted
+- **WHEN** a candidate changes policy phase from sealed to bootstrap
+- **THEN** CI rejects the change regardless of grant or signer
+
+#### Scenario: Trusted key rotates
+- **WHEN** an existing trusted key authorizes an otherwise valid policy change that introduces a replacement key without weakening immutable paths
+- **THEN** the replacement becomes trusted only after the authority commit merges

--- a/openspec/changes/add-break-glass-maintainer-mode/specs/repository-governance/spec.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/specs/repository-governance/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Authority maintenance is a fourth managed commit kind
+Repository governance SHALL recognize task, plan, archive, and
+authority-maintenance as the complete mutually exclusive managed commit kinds.
+
+#### Scenario: Authority trailers are canonical
+- **WHEN** the workflow engine creates an authority-maintenance commit
+- **THEN** its final trailer block contains exactly `Change`, `Transition: authority-maintenance`, and `Grant` in canonical order
+
+#### Scenario: Ordinary managed semantics remain unchanged
+- **WHEN** CI validates task, plan, or archive commits after authority-maintenance support is installed
+- **THEN** their existing trailer, scope, ordering, completion, and replay semantics remain unchanged
+
+### Requirement: Authority verification is base-owned
+The required workflow-assurance job MUST execute authority verification code and
+load signer, policy, phase, and immutable-path trust from the exact pull-request
+base or authority commit parent rather than the candidate branch.
+
+#### Scenario: Candidate modifies its verifier
+- **WHEN** a candidate authority commit changes verifier or trust-loading code
+- **THEN** the base-owned verifier applies the previous trusted rules to that commit before the candidate code can become authoritative
+
+#### Scenario: All normal checks remain required
+- **WHEN** an authority-maintenance commit is otherwise valid
+- **THEN** workflow-assurance still runs the complete check set required by trusted policy and the active change
+
+### Requirement: Authority audit prerequisites remain maintainer-owned
+Repository documentation SHALL distinguish checked-in enforcement from GitHub
+tag protection, protected-environment approval, required-check configuration,
+and repository-administrator recovery that only a maintainer can prove.
+
+#### Scenario: Repository files are merged before remote controls
+- **WHEN** the implementation is present but tag protection or the sealed approval environment has not been independently verified
+- **THEN** project status describes maintainer mode as bootstrap-only and does not claim sealed enforcement

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -10,7 +10,7 @@
 
 ## 3. Commit and Recovery
 
-- [ ] 3.1 Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
+- [x] 3.1 Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
 
 ## 4. Independent Assurance
 

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -14,7 +14,7 @@
 
 ## 4. Independent Assurance
 
-- [ ] 4.1 Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
+- [x] 4.1 Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
 - [ ] 4.2 Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
 
 ## 5. Operator Contract

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -19,4 +19,4 @@
 
 ## 5. Operator Contract
 
-- [ ] 5.1 Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.
+- [x] 5.1 Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Grant Contract and Issuance
 
 - [x] 1.1 Add the trusted maintainer policy, canonical grant model, exact-path validation, and maintainer-mode coverage under the existing workflow-test authority.
-- [ ] 1.2 Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
+- [x] 1.2 Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
 
 ## 2. Local Grant and Session State
 

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -15,7 +15,7 @@
 ## 4. Independent Assurance
 
 - [x] 4.1 Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
-- [ ] 4.2 Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
+- [x] 4.2 Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
 
 ## 5. Operator Contract
 

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -6,7 +6,7 @@
 ## 2. Local Grant and Session State
 
 - [x] 2.1 Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
-- [ ] 2.2 Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
+- [x] 2.2 Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
 
 ## 3. Commit and Recovery
 

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -5,7 +5,7 @@
 
 ## 2. Local Grant and Session State
 
-- [ ] 2.1 Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
+- [x] 2.1 Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
 - [ ] 2.2 Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
 
 ## 3. Commit and Recovery

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -1,0 +1,22 @@
+## 1. Grant Contract and Issuance
+
+- [ ] 1.1 Add the trusted maintainer policy, canonical grant model, exact-path validation, and maintainer-mode coverage under the existing workflow-test authority.
+- [ ] 1.2 Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
+
+## 2. Local Grant and Session State
+
+- [ ] 2.1 Add Git-common-directory grant storage, atomic reservation, inspection, idempotent revocation, and cross-worktree exclusion.
+- [ ] 2.2 Add authority session start/check transitions, pinned normal-check evidence, and terminal failure cleanup.
+
+## 3. Commit and Recovery
+
+- [ ] 3.1 Add signed authority commit isolation, canonical trailers, durable transaction journaling, and fail-closed crash recovery.
+
+## 4. Independent Assurance
+
+- [ ] 4.1 Add parent-policy authority replay, audit-tag and commit-signature verification, unique-use enforcement, and sealed trust-root rules.
+- [ ] 4.2 Run workflow assurance from the pull-request base and cover candidate-verifier, phase, rotation, expiry, and replay attacks.
+
+## 5. Operator Contract
+
+- [ ] 5.1 Document every maintainer command, bootstrap/pilot/sealing procedure, recovery boundary, and maintainer-owned remote prerequisite.

--- a/openspec/changes/add-break-glass-maintainer-mode/tasks.md
+++ b/openspec/changes/add-break-glass-maintainer-mode/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Grant Contract and Issuance
 
-- [ ] 1.1 Add the trusted maintainer policy, canonical grant model, exact-path validation, and maintainer-mode coverage under the existing workflow-test authority.
+- [x] 1.1 Add the trusted maintainer policy, canonical grant model, exact-path validation, and maintainer-mode coverage under the existing workflow-test authority.
 - [ ] 1.2 Add the human-present SSH signer, interactive grant command, and signed audit-tag creation.
 
 ## 2. Local Grant and Session State

--- a/packages/workflow-engine/src/ci-authority.ts
+++ b/packages/workflow-engine/src/ci-authority.ts
@@ -1,0 +1,603 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { canonicalCheckDefinition } from './ci-historical-contract.ts';
+import {
+  listCommitPaths,
+  readFileAtCommit,
+  type RangeCommit,
+} from './ci-git.ts';
+import {
+  parseCheckCommand,
+  parseTasks,
+  type CheckDefinition,
+} from './contracts.ts';
+import { ExitCode, workflowError } from './errors.ts';
+import { commitFacts } from './git-transitions.ts';
+import { runGit } from './git.ts';
+import {
+  canonicalGrantEnvelope,
+  canonicalGrantPayload,
+  parseMaintainerGrantEnvelope,
+  validateGrantPayload,
+  type MaintainerGrantEnvelope,
+} from './maintainer-grant.ts';
+import {
+  parseMaintainerPolicy,
+  type MaintainerPolicy,
+  type TrustedMaintainerSigner,
+} from './maintainer-policy.ts';
+import {
+  ManagedTrailerSyntaxError,
+  parseManagedTrailers,
+} from './managed-trailers.ts';
+
+export type CiAuthorityResult = {
+  grantId: string;
+  changeId: string;
+  allowedPaths: string[];
+  requiredCheckDefinitions: Record<string, string>;
+};
+
+export function validateCiAuthorityCommit(
+  repositoryRoot: string,
+  commit: RangeCommit,
+  evaluatedAt: Date = new Date(),
+): CiAuthorityResult {
+  if (commit.parents.length !== 1 || commit.trailers?.kind !== 'authority') {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_COMMIT_INVALID',
+      'Authority verification requires one canonical single-parent authority commit.',
+    );
+  }
+  const parent = commit.parents[0];
+  const policyContent = requiredFile(
+    repositoryRoot,
+    parent,
+    'workflow/maintainer-policy.json',
+  );
+  const parentPolicy = parsePolicy(
+    policyContent,
+    'CI_AUTHORITY_POLICY_INVALID',
+  );
+  const policyBlob = runGit(repositoryRoot, [
+    'rev-parse',
+    `${parent}:workflow/maintainer-policy.json`,
+  ]).trim();
+  const envelope = readAuditEnvelope(
+    repositoryRoot,
+    parent,
+    commit.trailers.grantId,
+    parentPolicy,
+  );
+  if (
+    envelope.payload.grantId !== commit.trailers.grantId ||
+    envelope.payload.changeId !== commit.trailers.changeId
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_GRANT_MISMATCH',
+      'Authority trailers do not match the protected grant envelope.',
+    );
+  }
+  const evaluationDate = exactDate(evaluatedAt);
+  validateGrantPayload(envelope.payload, parentPolicy, {
+    now: evaluationDate,
+    expectedBase: parent,
+    expectedPolicyBlob: policyBlob,
+  });
+  assertGrantValidAtCommit(repositoryRoot, commit.hash, envelope);
+  assertGrantPathsAtParent(
+    repositoryRoot,
+    parent,
+    envelope.payload.allowedPaths,
+  );
+  verifyEnvelopeSignature(envelope, parentPolicy);
+  verifyCommitSignature(
+    repositoryRoot,
+    commit.hash,
+    envelope.payload.signer,
+    parentPolicy,
+  );
+  assertGrantNotPreviouslyClaimed(
+    repositoryRoot,
+    parent,
+    envelope.payload.grantId,
+  );
+
+  const changedPaths = listCommitPaths(repositoryRoot, commit);
+  if (
+    changedPaths.length === 0 ||
+    changedPaths.some(
+      (filePath) => !envelope.payload.allowedPaths.includes(filePath),
+    )
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_SCOPE_INVALID',
+      'Authority commit contains a path absent from its exact grant.',
+      { changedPaths, allowedPaths: envelope.payload.allowedPaths },
+    );
+  }
+  assertPolicyTransition(repositoryRoot, parent, commit.hash, parentPolicy);
+
+  return {
+    grantId: envelope.payload.grantId,
+    changeId: envelope.payload.changeId,
+    allowedPaths: [...envelope.payload.allowedPaths],
+    requiredCheckDefinitions: loadAuthorityCheckDefinitions(
+      repositoryRoot,
+      parent,
+      envelope.payload.changeId,
+      parentPolicy.requiredChecks,
+    ),
+  };
+}
+
+function readAuditEnvelope(
+  repositoryRoot: string,
+  parent: string,
+  grantId: string,
+  policy: MaintainerPolicy,
+): MaintainerGrantEnvelope {
+  const tagRef = `${policy.auditTagPrefix}${grantId}`;
+  try {
+    const raw = runGit(repositoryRoot, ['cat-file', 'tag', tagRef]);
+    const separator = raw.indexOf('\n\n');
+    if (separator === -1) throw new Error('tag body missing');
+    const headers = raw.slice(0, separator).split('\n');
+    const objectHeaders = headers.filter((line) => line.startsWith('object '));
+    const typeHeaders = headers.filter((line) => line.startsWith('type '));
+    const tagHeaders = headers.filter((line) => line.startsWith('tag '));
+    if (
+      objectHeaders.length !== 1 ||
+      objectHeaders[0] !== `object ${parent}` ||
+      typeHeaders.length !== 1 ||
+      typeHeaders[0] !== 'type commit' ||
+      tagHeaders.length !== 1 ||
+      tagHeaders[0] !== `tag ${tagRef.slice('refs/tags/'.length)}`
+    ) {
+      throw new Error('tag headers differ');
+    }
+    const envelope = parseMaintainerGrantEnvelope(raw.slice(separator + 2));
+    if (canonicalGrantEnvelope(envelope) !== raw.slice(separator + 2)) {
+      throw new Error('tag envelope differs');
+    }
+    return envelope;
+  } catch {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_AUDIT_TAG_INVALID',
+      'The exact protected maintainer grant tag is missing or invalid.',
+    );
+  }
+}
+
+function verifyEnvelopeSignature(
+  envelope: MaintainerGrantEnvelope,
+  policy: MaintainerPolicy,
+): void {
+  const signer = trustedSigner(policy, envelope.payload.signer);
+  verifySshDataSignature(
+    canonicalGrantPayload(envelope.payload),
+    envelope.signature,
+    signer,
+    policy.signatureNamespace,
+    'CI_AUTHORITY_GRANT_SIGNATURE_INVALID',
+  );
+}
+
+function verifyCommitSignature(
+  repositoryRoot: string,
+  commitHash: string,
+  identity: string,
+  policy: MaintainerPolicy,
+): void {
+  const signer = trustedSigner(policy, identity);
+  const temporaryDirectory = privateTemporaryDirectory(
+    'workflow-ci-authority-commit-',
+  );
+  const allowedSigners = path.join(temporaryDirectory, 'allowed-signers');
+  try {
+    writePrivateFile(
+      allowedSigners,
+      `${signer.identity} ${signer.publicKey}\n`,
+    );
+    const output = runGit(repositoryRoot, [
+      '-c',
+      'gpg.format=ssh',
+      '-c',
+      `gpg.ssh.allowedSignersFile=${allowedSigners}`,
+      'show',
+      '-s',
+      '--format=%G?%x00%GS%x00%GF',
+      commitHash,
+    ]).trimEnd();
+    const [status, observedIdentity, fingerprint] = output.split('\0');
+    if (
+      status !== 'G' ||
+      observedIdentity !== signer.identity ||
+      fingerprint !== signer.fingerprint
+    ) {
+      throw new Error('untrusted commit signature');
+    }
+  } catch {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_COMMIT_SIGNATURE_INVALID',
+      'Authority commit is not signed by its parent-policy grant signer.',
+    );
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function verifySshDataSignature(
+  payload: string,
+  signature: string,
+  signer: TrustedMaintainerSigner,
+  namespace: string,
+  errorCode: string,
+): void {
+  const executable = sshKeygenExecutable();
+  const temporaryDirectory = privateTemporaryDirectory(
+    'workflow-ci-authority-grant-',
+  );
+  const allowedSigners = path.join(temporaryDirectory, 'allowed-signers');
+  const signaturePath = path.join(temporaryDirectory, 'signature');
+  try {
+    writePrivateFile(
+      allowedSigners,
+      `${signer.identity} ${signer.publicKey}\n`,
+    );
+    writePrivateFile(signaturePath, signature);
+    const result = spawnSync(
+      executable,
+      [
+        '-Y',
+        'verify',
+        '-f',
+        allowedSigners,
+        '-I',
+        signer.identity,
+        '-n',
+        namespace,
+        '-s',
+        signaturePath,
+      ],
+      {
+        encoding: 'utf8',
+        input: payload,
+        shell: false,
+        env: { PATH: '/usr/bin:/bin', LC_ALL: 'C' },
+      },
+    );
+    if (result.error || result.status !== 0) {
+      throw new Error('invalid SSH data signature');
+    }
+  } catch {
+    throw ciAuthorityError(
+      errorCode,
+      'Maintainer grant envelope signature is invalid or untrusted.',
+    );
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function assertGrantValidAtCommit(
+  repositoryRoot: string,
+  commitHash: string,
+  envelope: MaintainerGrantEnvelope,
+): void {
+  const rawTimestamp = runGit(repositoryRoot, [
+    'show',
+    '-s',
+    '--format=%cI',
+    commitHash,
+  ]).trim();
+  const committedAt = Date.parse(rawTimestamp);
+  const issuedAt = Date.parse(envelope.payload.issuedAt);
+  const expiresAt = Date.parse(envelope.payload.expiresAt);
+  if (
+    !Number.isFinite(committedAt) ||
+    committedAt < issuedAt ||
+    committedAt > expiresAt
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_GRANT_TIME_INVALID',
+      'Authority commit was not created within its signed grant lifetime.',
+    );
+  }
+}
+
+function assertGrantPathsAtParent(
+  repositoryRoot: string,
+  parent: string,
+  allowedPaths: string[],
+): void {
+  for (const filePath of allowedPaths) {
+    const output = runGit(repositoryRoot, [
+      'ls-tree',
+      '-z',
+      parent,
+      '--',
+      `:(literal)${filePath}`,
+    ]);
+    const match = /^(100644|100755) blob [0-9a-f]{40,64}\t([^\0]+)\0$/.exec(
+      output,
+    );
+    if (!match || match[2] !== filePath) {
+      throw ciAuthorityError(
+        'CI_AUTHORITY_GRANT_PATH_INVALID',
+        'Authority grant does not name an exact tracked parent regular file.',
+        { path: filePath },
+      );
+    }
+  }
+}
+
+function assertGrantNotPreviouslyClaimed(
+  repositoryRoot: string,
+  parent: string,
+  grantId: string,
+): void {
+  const ancestors = runGit(repositoryRoot, ['rev-list', parent])
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+  for (const hash of ancestors) {
+    try {
+      const trailers = parseManagedTrailers(
+        commitFacts(repositoryRoot, hash).message,
+      );
+      if (trailers?.kind === 'authority' && trailers.grantId === grantId) {
+        throw ciAuthorityError(
+          'CI_AUTHORITY_GRANT_REPLAYED',
+          'Authority grant was already claimed by an ancestor commit.',
+          { priorCommit: hash },
+        );
+      }
+    } catch (error) {
+      if (error instanceof ManagedTrailerSyntaxError) continue;
+      throw error;
+    }
+  }
+}
+
+function assertPolicyTransition(
+  repositoryRoot: string,
+  parent: string,
+  commitHash: string,
+  parentPolicy: MaintainerPolicy,
+): void {
+  const policyPath = 'workflow/maintainer-policy.json';
+  const before = requiredFile(repositoryRoot, parent, policyPath);
+  const after = readFileAtCommit(repositoryRoot, commitHash, policyPath);
+  if (after === before) return;
+  if (after === undefined) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_POLICY_REMOVED',
+      'Authority commit may not remove the maintainer policy.',
+    );
+  }
+  const candidate = parsePolicy(
+    after,
+    'CI_AUTHORITY_POLICY_TRANSITION_INVALID',
+  );
+  if (
+    JSON.stringify(candidate.repository) !==
+      JSON.stringify(parentPolicy.repository) ||
+    candidate.auditTagPrefix !== parentPolicy.auditTagPrefix ||
+    candidate.signatureNamespace !== parentPolicy.signatureNamespace ||
+    candidate.maxTtlMinutes !== parentPolicy.maxTtlMinutes ||
+    candidate.maxUses !== parentPolicy.maxUses ||
+    (parentPolicy.phase === 'sealed' && candidate.phase !== 'sealed') ||
+    parentPolicy.sealedImmutablePaths.some(
+      (filePath) => !candidate.sealedImmutablePaths.includes(filePath),
+    ) ||
+    parentPolicy.requiredChecks.some(
+      (checkId) => !candidate.requiredChecks.includes(checkId),
+    )
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_POLICY_TRANSITION_INVALID',
+      'Authority policy transition changes stable identity, rolls back phase, or weakens trust roots.',
+    );
+  }
+}
+
+function loadAuthorityCheckDefinitions(
+  repositoryRoot: string,
+  parent: string,
+  changeId: string,
+  policyChecks: string[],
+): Record<string, string> {
+  const tasks = parseTasks(
+    requiredFile(
+      repositoryRoot,
+      parent,
+      `openspec/changes/${changeId}/tasks.md`,
+    ),
+  );
+  const guard = parseJson(
+    requiredFile(
+      repositoryRoot,
+      parent,
+      `openspec/changes/${changeId}/guard.json`,
+    ),
+  );
+  if (
+    !isRecord(guard) ||
+    !hasExactKeys(guard, ['schemaVersion', 'changeId', 'tasks']) ||
+    guard.schemaVersion !== 1 ||
+    guard.changeId !== changeId ||
+    !isRecord(guard.tasks) ||
+    JSON.stringify(Object.keys(guard.tasks).sort()) !==
+      JSON.stringify(tasks.map(({ id }) => id).sort())
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_PARENT_GUARD_INVALID',
+      'Authority change does not have a valid parent guard contract.',
+    );
+  }
+  const taskChecks = Object.values(guard.tasks).flatMap((value) => {
+    if (
+      !isRecord(value) ||
+      !hasExactKeys(value, ['allowedPaths', 'requiredChecks']) ||
+      !isStringArray(value.allowedPaths) ||
+      value.allowedPaths.length === 0 ||
+      !isStringArray(value.requiredChecks) ||
+      value.requiredChecks.length === 0
+    ) {
+      throw ciAuthorityError(
+        'CI_AUTHORITY_PARENT_GUARD_INVALID',
+        'Authority parent guard contains an invalid task policy.',
+      );
+    }
+    return value.requiredChecks;
+  });
+  const requiredChecks = [...new Set([...policyChecks, ...taskChecks])].sort();
+  const checksDocument = parseJson(
+    requiredFile(repositoryRoot, parent, 'workflow/checks.json'),
+  );
+  if (
+    !isRecord(checksDocument) ||
+    !hasExactKeys(checksDocument, ['schemaVersion', 'checks']) ||
+    checksDocument.schemaVersion !== 1 ||
+    !isRecord(checksDocument.checks)
+  ) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_PARENT_CHECKS_INVALID',
+      'Authority parent check registry is invalid.',
+    );
+  }
+  const checkRegistry = checksDocument.checks;
+  return Object.fromEntries(
+    requiredChecks.map((checkId) => {
+      const value = checkRegistry[checkId];
+      if (
+        !isRecord(value) ||
+        !hasExactKeys(value, ['command', 'destructiveDatabase']) ||
+        !isStringArray(value.command) ||
+        !parseCheckCommand(value.command) ||
+        typeof value.destructiveDatabase !== 'boolean'
+      ) {
+        throw ciAuthorityError(
+          'CI_AUTHORITY_PARENT_CHECKS_INVALID',
+          `Authority parent check is missing or invalid: ${checkId}.`,
+        );
+      }
+      const definition: CheckDefinition = {
+        command: value.command,
+        destructiveDatabase: value.destructiveDatabase,
+      };
+      return [checkId, canonicalCheckDefinition(definition)];
+    }),
+  );
+}
+
+function trustedSigner(
+  policy: MaintainerPolicy,
+  identity: string,
+): TrustedMaintainerSigner {
+  const signer = policy.trustedSigners.find(
+    (candidate) => candidate.identity === identity,
+  );
+  if (!signer) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_SIGNER_UNTRUSTED',
+      'Authority grant signer is absent from the parent policy.',
+    );
+  }
+  return signer;
+}
+
+function requiredFile(
+  repositoryRoot: string,
+  commit: string,
+  filePath: string,
+): string {
+  const content = readFileAtCommit(repositoryRoot, commit, filePath);
+  if (content === undefined) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_PARENT_CONTRACT_MISSING',
+      `Authority parent is missing ${filePath}.`,
+    );
+  }
+  return content;
+}
+
+function parsePolicy(content: string, code: string): MaintainerPolicy {
+  try {
+    return parseMaintainerPolicy(JSON.parse(content));
+  } catch {
+    throw ciAuthorityError(code, 'Maintainer policy is invalid.');
+  }
+}
+
+function parseJson(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+}
+
+function sshKeygenExecutable(): string {
+  for (const candidate of ['/usr/bin/ssh-keygen', '/bin/ssh-keygen']) {
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  throw ciAuthorityError(
+    'CI_AUTHORITY_SIGNER_UNAVAILABLE',
+    'OpenSSH signature verification is unavailable.',
+  );
+}
+
+function privateTemporaryDirectory(prefix: string): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  fs.chmodSync(directory, 0o700);
+  return directory;
+}
+
+function writePrivateFile(filePath: string, content: string): void {
+  fs.writeFileSync(filePath, content, { encoding: 'utf8', mode: 0o600 });
+  fs.chmodSync(filePath, 0o600);
+}
+
+function exactDate(value: Date): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw ciAuthorityError(
+      'CI_AUTHORITY_EVALUATION_TIME_INVALID',
+      'Authority CI evaluation time is invalid.',
+    );
+  }
+  return date;
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  expected: string[],
+): boolean {
+  return (
+    JSON.stringify(Object.keys(value).sort()) ===
+    JSON.stringify([...expected].sort())
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) && value.every((entry) => typeof entry === 'string')
+  );
+}
+
+function ciAuthorityError(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) {
+  return workflowError(code, message, ExitCode.verification, { details });
+}

--- a/packages/workflow-engine/src/ci-sequence.ts
+++ b/packages/workflow-engine/src/ci-sequence.ts
@@ -147,6 +147,12 @@ export function replayCommitSequence(
       archivedChanges.add(archive.changeId);
       continue;
     }
+    if (commit.trailers.kind === 'authority') {
+      throw ciError(
+        'CI_AUTHORITY_VERIFIER_REQUIRED',
+        'Authority commits require independent parent-policy verification.',
+      );
+    }
 
     const transitions = taskTransitionsForCommit(repositoryRoot, commit);
     if (transitions.length === 0) {

--- a/packages/workflow-engine/src/ci-sequence.ts
+++ b/packages/workflow-engine/src/ci-sequence.ts
@@ -1,4 +1,5 @@
 import { validateCiArchiveCommit } from './ci-archive.ts';
+import { validateCiAuthorityCommit } from './ci-authority.ts';
 import { assertExactPlanningBootstrap } from './ci-bootstrap.ts';
 import {
   loadHistoricalTaskAuthority,
@@ -30,6 +31,7 @@ import { assertExactTaskProjection } from './task-projection.ts';
 export type CommitSequenceResult = {
   completedTasks: CompletedTask[];
   archivedChanges: string[];
+  authorityGrants: string[];
   requiredCheckDefinitions: Record<string, string>;
 };
 
@@ -39,10 +41,12 @@ export function replayCommitSequence(
   contracts: Map<string, ChangeContract>,
   legacyExceptions: BootstrapException[],
   planningBootstrapPolicies: PlanningBootstrapException[],
+  evaluatedAt: Date = new Date(),
 ): CommitSequenceResult {
   const priorTaskTrailers = new Set<string>();
   const completedTasks = new Map<string, CompletedTask>();
   const archivedChanges = new Set<string>();
+  const authorityGrants = new Set<string>();
   const requiredCheckDefinitions = new Map<string, string>();
   const completionPaths = completionDocumentPaths(repositoryRoot);
   const expectedCompatibility = legacyExceptions.flatMap((exception) =>
@@ -148,10 +152,23 @@ export function replayCommitSequence(
       continue;
     }
     if (commit.trailers.kind === 'authority') {
-      throw ciError(
-        'CI_AUTHORITY_VERIFIER_REQUIRED',
-        'Authority commits require independent parent-policy verification.',
+      if (authorityGrants.has(commit.trailers.grantId)) {
+        throw ciError(
+          'CI_AUTHORITY_GRANT_DUPLICATE',
+          'A pull-request range may claim each authority grant only once.',
+        );
+      }
+      const authority = validateCiAuthorityCommit(
+        repositoryRoot,
+        commit,
+        evaluatedAt,
       );
+      recordDefinitions(
+        requiredCheckDefinitions,
+        authority.requiredCheckDefinitions,
+      );
+      authorityGrants.add(authority.grantId);
+      continue;
     }
 
     const transitions = taskTransitionsForCommit(repositoryRoot, commit);
@@ -197,6 +214,7 @@ export function replayCommitSequence(
   return {
     completedTasks: [...completedTasks.values()].sort(compareTasks),
     archivedChanges: [...archivedChanges].sort(),
+    authorityGrants: [...authorityGrants].sort(),
     requiredCheckDefinitions: Object.fromEntries(
       [...requiredCheckDefinitions].sort(([left], [right]) =>
         left.localeCompare(right),

--- a/packages/workflow-engine/src/ci.ts
+++ b/packages/workflow-engine/src/ci.ts
@@ -38,6 +38,7 @@ export function verifyPullRequest(
   requestedBase: string,
   requestedHead: string,
   environment: NodeJS.ProcessEnv = process.env,
+  evaluatedAt: Date = new Date(),
 ) {
   const git = discoverRepository(cwd);
   const base = assertCiCommit(git.repositoryRoot, requestedBase);
@@ -92,6 +93,7 @@ export function verifyPullRequest(
     contracts,
     exceptions,
     loadPlanningBootstrapPolicy(git.repositoryRoot),
+    evaluatedAt,
   );
   const completedTasks = replay.completedTasks;
   const changedPaths = listRangePaths(git.repositoryRoot, mergeBase, head);
@@ -110,6 +112,7 @@ export function verifyPullRequest(
     commits: commits.map(({ hash }) => hash),
     completedTasks,
     archivedChanges: replay.archivedChanges,
+    authorityGrants: replay.authorityGrants,
     changedPaths,
     checks,
     managedDocuments: validated.documents,

--- a/packages/workflow-engine/src/cli.ts
+++ b/packages/workflow-engine/src/cli.ts
@@ -27,6 +27,8 @@ import {
   inspectMaintainerGrants,
   revokeMaintainerGrant,
 } from './maintainer-store.ts';
+import { commitAuthoritySession } from './maintainer-commit.ts';
+import { recoverAuthorityCommit } from './maintainer-recovery.ts';
 import {
   abortAuthoritySession,
   checkAuthoritySession,
@@ -288,6 +290,32 @@ function dispatch(args: string[], cwd: string): CommandResult {
         command,
         ok: true,
         result: checkAuthoritySession(cwd, rest[0]),
+      };
+    case 'authority-commit': {
+      const sessionId = rest[0];
+      const message = optionValue(rest.slice(1), '--message');
+      if (
+        !sessionId ||
+        !message ||
+        rest.length !== 3 ||
+        rest[1] !== '--message'
+      ) {
+        throw usage(
+          'Usage: pnpm workflow authority-commit <session-id> --message <subject> [--json]',
+        );
+      }
+      return {
+        command,
+        ok: true,
+        result: commitAuthoritySession(cwd, sessionId, message),
+      };
+    }
+    case 'authority-recover':
+      requireArgumentCount(command, rest, 1, 1);
+      return {
+        command,
+        ok: true,
+        result: recoverAuthorityCommit(cwd, rest[0]),
       };
     case 'authority-abort': {
       const sessionId = rest[0];
@@ -596,6 +624,8 @@ function usageText(): string {
     '  pnpm workflow maintainer revoke <grant-id> [--json]',
     '  pnpm workflow authority-start <change-id> --grant <grant-id> [--json]',
     '  pnpm workflow authority-check <session-id> [--json]',
+    '  pnpm workflow authority-commit <session-id> --message <subject> [--json]',
+    '  pnpm workflow authority-recover <session-id> [--json]',
     '  pnpm workflow authority-abort <session-id> --reason <text> [--json]',
     '  pnpm workflow documents validate [--json]',
     '  pnpm workflow document-refresh <propose|show|review|apply> ... [--json]',

--- a/packages/workflow-engine/src/cli.ts
+++ b/packages/workflow-engine/src/cli.ts
@@ -24,6 +24,10 @@ import {
   type MaintainerGrantRequest,
 } from './maintainer-grant.ts';
 import {
+  inspectMaintainerGrants,
+  revokeMaintainerGrant,
+} from './maintainer-store.ts';
+import {
   commitSession,
   completeTask,
   findTaskCommits,
@@ -226,18 +230,38 @@ function dispatch(args: string[], cwd: string): CommandResult {
         ),
       };
     case 'maintainer': {
-      const request = parseMaintainerGrantArguments(rest);
-      const grant = issueMaintainerGrant(cwd, request);
-      return {
-        command,
-        action: 'grant',
-        ok: true,
-        grantId: grant.grantId,
-        tagRef: grant.tagRef,
-        expiresAt: grant.envelope.payload.expiresAt,
-        allowedPaths: grant.envelope.payload.allowedPaths,
-        publishCommand: grant.publishCommand,
-      };
+      if (rest[0] === 'grant') {
+        const request = parseMaintainerGrantArguments(rest);
+        const grant = issueMaintainerGrant(cwd, request);
+        return {
+          command,
+          action: 'grant',
+          ok: true,
+          grantId: grant.grantId,
+          tagRef: grant.tagRef,
+          expiresAt: grant.envelope.payload.expiresAt,
+          allowedPaths: grant.envelope.payload.allowedPaths,
+          publishCommand: grant.publishCommand,
+        };
+      }
+      const git = discoverRepository(cwd);
+      if (rest[0] === 'inspect' && rest.length <= 2) {
+        return {
+          command,
+          action: 'inspect',
+          ok: true,
+          grants: inspectMaintainerGrants(git.gitCommonDirectory, rest[1]),
+        };
+      }
+      if (rest[0] === 'revoke' && rest.length === 2) {
+        return {
+          command,
+          action: 'revoke',
+          ok: true,
+          grant: revokeMaintainerGrant(git.gitCommonDirectory, rest[1]),
+        };
+      }
+      throw maintainerUsage();
     }
     case 'documents':
       if (rest.length !== 1 || rest[0] !== 'validate') {
@@ -486,6 +510,12 @@ function maintainerGrantUsage(): WorkflowError {
   );
 }
 
+function maintainerUsage(): WorkflowError {
+  return usage(
+    'Usage: pnpm workflow maintainer <grant ...|inspect [grant-id]|revoke <grant-id>> [--json]',
+  );
+}
+
 function requireArgumentCount(
   command: string,
   args: string[],
@@ -517,6 +547,8 @@ function usageText(): string {
     '  pnpm workflow adapter evaluate [--json]',
     '  pnpm workflow issue <add|update|close|render|validate> ... [--json]',
     '  pnpm workflow maintainer grant --change <change-id> --paths <exact-path> [--paths <exact-path> ...] --reason <text> [--ttl <minutes>m] [--uses 1] [--json]',
+    '  pnpm workflow maintainer inspect [grant-id] [--json]',
+    '  pnpm workflow maintainer revoke <grant-id> [--json]',
     '  pnpm workflow documents validate [--json]',
     '  pnpm workflow document-refresh <propose|show|review|apply> ... [--json]',
     '  pnpm workflow handoff <render|validate> [--json]',

--- a/packages/workflow-engine/src/cli.ts
+++ b/packages/workflow-engine/src/cli.ts
@@ -28,6 +28,11 @@ import {
   revokeMaintainerGrant,
 } from './maintainer-store.ts';
 import {
+  abortAuthoritySession,
+  checkAuthoritySession,
+  startAuthoritySession,
+} from './maintainer-session.ts';
+import {
   commitSession,
   completeTask,
   findTaskCommits,
@@ -262,6 +267,46 @@ function dispatch(args: string[], cwd: string): CommandResult {
         };
       }
       throw maintainerUsage();
+    }
+    case 'authority-start': {
+      const changeId = rest[0];
+      const grantId = optionValue(rest.slice(1), '--grant');
+      if (!changeId || !grantId || rest.length !== 3 || rest[1] !== '--grant') {
+        throw usage(
+          'Usage: pnpm workflow authority-start <change-id> --grant <grant-id> [--json]',
+        );
+      }
+      return {
+        command,
+        ok: true,
+        session: startAuthoritySession(cwd, changeId, grantId),
+      };
+    }
+    case 'authority-check':
+      requireArgumentCount(command, rest, 1, 1);
+      return {
+        command,
+        ok: true,
+        result: checkAuthoritySession(cwd, rest[0]),
+      };
+    case 'authority-abort': {
+      const sessionId = rest[0];
+      const reason = optionValue(rest.slice(1), '--reason');
+      if (
+        !sessionId ||
+        !reason ||
+        rest.length !== 3 ||
+        rest[1] !== '--reason'
+      ) {
+        throw usage(
+          'Usage: pnpm workflow authority-abort <session-id> --reason <text> [--json]',
+        );
+      }
+      return {
+        command,
+        ok: true,
+        session: abortAuthoritySession(cwd, sessionId, reason),
+      };
     }
     case 'documents':
       if (rest.length !== 1 || rest[0] !== 'validate') {
@@ -549,6 +594,9 @@ function usageText(): string {
     '  pnpm workflow maintainer grant --change <change-id> --paths <exact-path> [--paths <exact-path> ...] --reason <text> [--ttl <minutes>m] [--uses 1] [--json]',
     '  pnpm workflow maintainer inspect [grant-id] [--json]',
     '  pnpm workflow maintainer revoke <grant-id> [--json]',
+    '  pnpm workflow authority-start <change-id> --grant <grant-id> [--json]',
+    '  pnpm workflow authority-check <session-id> [--json]',
+    '  pnpm workflow authority-abort <session-id> --reason <text> [--json]',
     '  pnpm workflow documents validate [--json]',
     '  pnpm workflow document-refresh <propose|show|review|apply> ... [--json]',
     '  pnpm workflow handoff <render|validate> [--json]',

--- a/packages/workflow-engine/src/cli.ts
+++ b/packages/workflow-engine/src/cli.ts
@@ -20,6 +20,10 @@ import { renderHandoff, validateHandoff } from './handoff.ts';
 import { runRepositoryHook } from './hooks.ts';
 import { dispatchIssueCommand } from './issue-cli.ts';
 import {
+  issueMaintainerGrant,
+  type MaintainerGrantRequest,
+} from './maintainer-grant.ts';
+import {
   commitSession,
   completeTask,
   findTaskCommits,
@@ -221,6 +225,20 @@ function dispatch(args: string[], cwd: string): CommandResult {
           discoverRepository(cwd).repositoryRoot,
         ),
       };
+    case 'maintainer': {
+      const request = parseMaintainerGrantArguments(rest);
+      const grant = issueMaintainerGrant(cwd, request);
+      return {
+        command,
+        action: 'grant',
+        ok: true,
+        grantId: grant.grantId,
+        tagRef: grant.tagRef,
+        expiresAt: grant.envelope.payload.expiresAt,
+        allowedPaths: grant.envelope.payload.allowedPaths,
+        publishCommand: grant.publishCommand,
+      };
+    }
     case 'documents':
       if (rest.length !== 1 || rest[0] !== 'validate') {
         throw usage('Usage: pnpm workflow documents validate [--json]');
@@ -400,6 +418,74 @@ function optionValue(args: string[], name: string): string | undefined {
   return index === -1 ? undefined : args[index + 1];
 }
 
+function parseMaintainerGrantArguments(args: string[]): MaintainerGrantRequest {
+  if (args[0] !== 'grant') {
+    throw maintainerGrantUsage();
+  }
+  const values = args.slice(1);
+  const paths: string[] = [];
+  let changeId: string | undefined;
+  let reason: string | undefined;
+  let ttlMinutes: number | undefined;
+  let maxUses: number | undefined;
+
+  for (let index = 0; index < values.length; index += 2) {
+    const option = values[index];
+    const value = values[index + 1];
+    if (!option || !value || !option.startsWith('--')) {
+      throw maintainerGrantUsage();
+    }
+    switch (option) {
+      case '--change':
+        if (changeId !== undefined) {
+          throw maintainerGrantUsage();
+        }
+        changeId = value;
+        break;
+      case '--paths':
+        paths.push(value);
+        break;
+      case '--reason':
+        if (reason !== undefined) {
+          throw maintainerGrantUsage();
+        }
+        reason = value;
+        break;
+      case '--ttl': {
+        if (ttlMinutes !== undefined || !/^[1-9][0-9]*m$/.test(value)) {
+          throw maintainerGrantUsage();
+        }
+        ttlMinutes = Number.parseInt(value.slice(0, -1), 10);
+        break;
+      }
+      case '--uses':
+        if (maxUses !== undefined || !/^[1-9][0-9]*$/.test(value)) {
+          throw maintainerGrantUsage();
+        }
+        maxUses = Number.parseInt(value, 10);
+        break;
+      default:
+        throw maintainerGrantUsage();
+    }
+  }
+  if (!changeId || paths.length === 0 || !reason) {
+    throw maintainerGrantUsage();
+  }
+  return {
+    changeId,
+    paths,
+    reason,
+    ...(ttlMinutes === undefined ? {} : { ttlMinutes }),
+    ...(maxUses === undefined ? {} : { maxUses }),
+  };
+}
+
+function maintainerGrantUsage(): WorkflowError {
+  return usage(
+    'Usage: pnpm workflow maintainer grant --change <change-id> --paths <exact-path> [--paths <exact-path> ...] --reason <text> [--ttl <minutes>m] [--uses 1] [--json]',
+  );
+}
+
 function requireArgumentCount(
   command: string,
   args: string[],
@@ -430,6 +516,7 @@ function usageText(): string {
     '  pnpm workflow ci --base <commit> --head <commit> [--json]',
     '  pnpm workflow adapter evaluate [--json]',
     '  pnpm workflow issue <add|update|close|render|validate> ... [--json]',
+    '  pnpm workflow maintainer grant --change <change-id> --paths <exact-path> [--paths <exact-path> ...] --reason <text> [--ttl <minutes>m] [--uses 1] [--json]',
     '  pnpm workflow documents validate [--json]',
     '  pnpm workflow document-refresh <propose|show|review|apply> ... [--json]',
     '  pnpm workflow handoff <render|validate> [--json]',

--- a/packages/workflow-engine/src/contract-artifacts.ts
+++ b/packages/workflow-engine/src/contract-artifacts.ts
@@ -22,6 +22,10 @@ export function workflowContractArtifactPaths(
     'workflow/document-policy.json',
   );
   const ciPolicy = path.join(repositoryRoot, 'workflow/ci-policy.json');
+  const maintainerPolicy = path.join(
+    repositoryRoot,
+    'workflow/maintainer-policy.json',
+  );
   return [
     ...required,
     ...schemas,
@@ -30,6 +34,9 @@ export function workflowContractArtifactPaths(
       : []),
     ...(fs.statSync(ciPolicy, { throwIfNoEntry: false })?.isFile()
       ? [ciPolicy]
+      : []),
+    ...(fs.statSync(maintainerPolicy, { throwIfNoEntry: false })?.isFile()
+      ? [maintainerPolicy]
       : []),
   ].sort();
 }

--- a/packages/workflow-engine/src/git-transitions.ts
+++ b/packages/workflow-engine/src/git-transitions.ts
@@ -322,6 +322,34 @@ export function createArchiveCommitObject(
   ).trim();
 }
 
+export function createSignedAuthorityCommitObject(
+  repositoryRoot: string,
+  tree: string,
+  parent: string,
+  subject: string,
+  changeId: string,
+  grantId: string,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  validateCommitSubject(subject);
+  const identity = resolveCommitIdentity(repositoryRoot, environment);
+  return runGitWithEnvironment(
+    repositoryRoot,
+    [
+      'commit-tree',
+      tree,
+      '-p',
+      parent,
+      '-S',
+      '-m',
+      subject,
+      '-m',
+      `Change: ${changeId}\nTransition: authority-maintenance\nGrant: ${grantId}`,
+    ],
+    identity,
+  ).trim();
+}
+
 export function updateManagedRef(
   repositoryRoot: string,
   expectedHead: string,
@@ -357,6 +385,21 @@ export function archiveCommitMessage(changeId: string): string {
   return [subject, '', `Change: ${changeId}`, 'Transition: archive'].join('\n');
 }
 
+export function authorityCommitMessage(
+  subject: string,
+  changeId: string,
+  grantId: string,
+): string {
+  validateCommitSubject(subject);
+  return [
+    subject,
+    '',
+    `Change: ${changeId}`,
+    'Transition: authority-maintenance',
+    `Grant: ${grantId}`,
+  ].join('\n');
+}
+
 export function managedCommitMessage(
   subject: string,
   changeId: string,
@@ -374,7 +417,7 @@ function validateCommitSubject(subject: string): void {
       const codePoint = character.codePointAt(0) ?? 0;
       return codePoint <= 31 || codePoint === 127;
     }) ||
-    /^(?:Change|Task):/i.test(subject)
+    /^(?:Change|Task|Transition|Grant):/i.test(subject)
   ) {
     throw workflowError(
       'INVALID_COMMIT_SUBJECT',

--- a/packages/workflow-engine/src/hooks.ts
+++ b/packages/workflow-engine/src/hooks.ts
@@ -49,7 +49,7 @@ export function runRepositoryHook(
     if (stagedLifecyclePaths.length > 0) {
       throw workflowError(
         'MANAGED_DIFF_REQUIRES_WORKFLOW_COMMIT',
-        'OpenSpec task, planning, and archive diffs require a workflow commit-tree transition.',
+        'OpenSpec task, planning, archive, and authority diffs require a workflow commit-tree transition.',
         ExitCode.guard,
         { details: { stagedPaths: stagedLifecyclePaths } },
       );

--- a/packages/workflow-engine/src/maintainer-commit.ts
+++ b/packages/workflow-engine/src/maintainer-commit.ts
@@ -1,0 +1,224 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ExitCode, workflowError } from './errors.ts';
+import {
+  createSignedAuthorityCommitObject,
+  stageExactPaths,
+  updateManagedRef,
+} from './git-transitions.ts';
+import {
+  discoverRepository,
+  fingerprintWorkingState,
+  listChangedPaths,
+  runGit,
+} from './git.ts';
+import {
+  beginAuthorityCommitJournal,
+  recordAuthorityCommitCreated,
+  recordAuthorityRefUpdated,
+  recoverAuthorityCommit,
+  verifyCreatedAuthorityCommit,
+  type AuthorityCommitResult,
+} from './maintainer-recovery.ts';
+import { readCurrentAuthorityCheckReport } from './maintainer-report.ts';
+import {
+  failAuthoritySession,
+  inspectActiveAuthoritySession,
+  type AuthoritySessionOptions,
+} from './maintainer-session.ts';
+import { maintainerGrantStorePaths } from './maintainer-store.ts';
+import { createInteractiveSshSigner } from './maintainer-signer.ts';
+import { withRepositoryLifecycleOperation } from './session-store.ts';
+
+export type AuthorityCommitOptions = AuthoritySessionOptions & {
+  testCrashAfter?: 'commit-created' | 'ref-updated';
+};
+
+export class SimulatedAuthorityCrash extends Error {
+  constructor(state: 'commit-created' | 'ref-updated') {
+    super(`Simulated authority crash after ${state}.`);
+    this.name = 'SimulatedAuthorityCrash';
+  }
+}
+
+export function commitAuthoritySession(
+  cwd: string,
+  requestedSessionId: string,
+  subject: string,
+  options: AuthorityCommitOptions = {},
+): AuthorityCommitResult {
+  const discovered = discoverRepository(cwd);
+  const store = maintainerGrantStorePaths(discovered.gitCommonDirectory);
+  const journalPath = path.join(store.journals, `${requestedSessionId}.json`);
+  if (fs.existsSync(journalPath)) {
+    return recoverAuthorityCommit(cwd, requestedSessionId, options.now);
+  }
+
+  const inspection = inspectActiveAuthoritySession(
+    cwd,
+    requestedSessionId,
+    options,
+  );
+  const signer =
+    options.signer ??
+    createInteractiveSshSigner(
+      inspection.git.repositoryRoot,
+      inspection.policy,
+    );
+  let journalCreated = false;
+  try {
+    signer.assertHumanPresent();
+    if (signer.identity() !== inspection.session.signer) {
+      throw commitError(
+        'AUTHORITY_COMMIT_SIGNER_MISMATCH',
+        'The human-present signer differs from the signed grant.',
+      );
+    }
+    assertGitSigningConfiguration(inspection.git.repositoryRoot);
+
+    const result = withRepositoryLifecycleOperation(
+      store.runtime,
+      (assertOwned) => {
+        assertOwned();
+        const current = inspectActiveAuthoritySession(
+          cwd,
+          requestedSessionId,
+          options,
+        );
+        if (
+          JSON.stringify(current.session) !== JSON.stringify(inspection.session)
+        ) {
+          throw commitError(
+            'AUTHORITY_SESSION_CHANGED',
+            'Authority session changed before commit creation.',
+          );
+        }
+        const changedPaths = listChangedPaths(
+          current.git.repositoryRoot,
+          current.session.baseCommit,
+        );
+        if (
+          changedPaths.length === 0 ||
+          changedPaths.some(
+            (filePath) => !current.session.allowedPaths.includes(filePath),
+          )
+        ) {
+          throw commitError(
+            'AUTHORITY_COMMIT_SCOPE_INVALID',
+            'Authority commit requires at least one change and only exact grant paths.',
+          );
+        }
+        const fingerprint = fingerprintWorkingState(
+          current.git.repositoryRoot,
+          current.git.head,
+          current.git.statusEntries,
+        );
+        readCurrentAuthorityCheckReport(
+          store.runtime.reports,
+          current.session,
+          changedPaths,
+          fingerprint,
+        );
+        const staged = stageExactPaths(
+          current.git.repositoryRoot,
+          current.session.baseCommit,
+          changedPaths,
+        );
+        let journal = beginAuthorityCommitJournal(current.session, {
+          expectedTree: staged.tree,
+          previousIndexTree: staged.previousIndexTree,
+          changedPaths,
+          subject,
+          now: exactDate(options.now ?? new Date()),
+        });
+        journalCreated = true;
+        const commitHash = createSignedAuthorityCommitObject(
+          current.git.repositoryRoot,
+          staged.tree,
+          current.session.baseCommit,
+          subject,
+          current.session.changeId,
+          current.session.grantId,
+          options.environment,
+        );
+        journal = recordAuthorityCommitCreated(
+          current.session.gitCommonDirectory,
+          journal,
+          commitHash,
+          exactDate(options.now ?? new Date()),
+        );
+        verifyCreatedAuthorityCommit(cwd, current.session, journal);
+        if (options.testCrashAfter === 'commit-created') {
+          throw new SimulatedAuthorityCrash('commit-created');
+        }
+        updateManagedRef(
+          current.git.repositoryRoot,
+          current.session.baseCommit,
+          commitHash,
+        );
+        journal = recordAuthorityRefUpdated(
+          current.session.gitCommonDirectory,
+          journal,
+          exactDate(options.now ?? new Date()),
+        );
+        if (options.testCrashAfter === 'ref-updated') {
+          throw new SimulatedAuthorityCrash('ref-updated');
+        }
+        return { commitHash, journal };
+      },
+      { allowMaintainerGrantId: inspection.session.grantId },
+    );
+    if (!result.commitHash) {
+      throw commitError(
+        'AUTHORITY_COMMIT_INVALID',
+        'Authority commit transaction did not create a commit.',
+      );
+    }
+    return recoverAuthorityCommit(cwd, requestedSessionId, options.now);
+  } catch (error) {
+    if (error instanceof SimulatedAuthorityCrash) {
+      throw error;
+    }
+    if (journalCreated) {
+      return recoverAuthorityCommit(cwd, requestedSessionId, options.now);
+    }
+    failAuthoritySession(inspection.session, error, options.now);
+    throw error;
+  }
+}
+
+function assertGitSigningConfiguration(repositoryRoot: string): void {
+  const format = runGit(
+    repositoryRoot,
+    ['config', '--local', '--get', 'gpg.format'],
+    true,
+  ).trim();
+  const key = runGit(
+    repositoryRoot,
+    ['config', '--local', '--get', 'user.signingkey'],
+    true,
+  ).trim();
+  if (format !== 'ssh' || !key) {
+    throw workflowError(
+      'AUTHORITY_GIT_SIGNING_REQUIRED',
+      'Authority commit requires local gpg.format=ssh and user.signingkey configuration.',
+      ExitCode.unsafeEnvironment,
+    );
+  }
+}
+
+function exactDate(value: Date): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw commitError(
+      'AUTHORITY_COMMIT_TIME_INVALID',
+      'Authority commit requires an exact timestamp.',
+    );
+  }
+  return date;
+}
+
+function commitError(code: string, message: string) {
+  return workflowError(code, message, ExitCode.staleState);
+}

--- a/packages/workflow-engine/src/maintainer-grant.ts
+++ b/packages/workflow-engine/src/maintainer-grant.ts
@@ -1,0 +1,242 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ExitCode, workflowError } from './errors.ts';
+import { runGit } from './git.ts';
+import {
+  isAuthorityPathEligible,
+  type MaintainerPolicy,
+} from './maintainer-policy.ts';
+import {
+  assertChangeId,
+  assertPolicyPathInsideRepository,
+  normalizeExactRepositoryPath,
+} from './paths.ts';
+
+const COMMIT_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
+const GRANT_ID =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+const PAYLOAD_KEYS = [
+  'version',
+  'grantId',
+  'repositoryId',
+  'repositoryOrigin',
+  'baseCommit',
+  'policyBlob',
+  'changeId',
+  'allowedPaths',
+  'issuedAt',
+  'expiresAt',
+  'maxUses',
+  'reason',
+  'signer',
+];
+
+export type MaintainerGrantPayload = {
+  version: 1;
+  grantId: string;
+  repositoryId: string;
+  repositoryOrigin: string;
+  baseCommit: string;
+  policyBlob: string;
+  changeId: string;
+  allowedPaths: string[];
+  issuedAt: string;
+  expiresAt: string;
+  maxUses: 1;
+  reason: string;
+  signer: string;
+};
+
+export type GrantValidationOptions = {
+  now: Date;
+  expectedBase: string;
+  expectedPolicyBlob: string;
+  allowExpired?: boolean;
+};
+
+export function canonicalGrantPayload(payload: MaintainerGrantPayload): string {
+  return `${JSON.stringify({
+    version: payload.version,
+    grantId: payload.grantId,
+    repositoryId: payload.repositoryId,
+    repositoryOrigin: payload.repositoryOrigin,
+    baseCommit: payload.baseCommit,
+    policyBlob: payload.policyBlob,
+    changeId: payload.changeId,
+    allowedPaths: payload.allowedPaths,
+    issuedAt: payload.issuedAt,
+    expiresAt: payload.expiresAt,
+    maxUses: payload.maxUses,
+    reason: payload.reason,
+    signer: payload.signer,
+  })}\n`;
+}
+
+export function validateGrantPayload(
+  payload: MaintainerGrantPayload,
+  policy: MaintainerPolicy,
+  options: GrantValidationOptions,
+): void {
+  if (
+    typeof payload !== 'object' ||
+    payload === null ||
+    Array.isArray(payload) ||
+    !hasExactKeys(
+      payload as unknown as Record<string, unknown>,
+      PAYLOAD_KEYS,
+    ) ||
+    payload.version !== 1 ||
+    !GRANT_ID.test(payload.grantId) ||
+    payload.repositoryId !== policy.repository.id ||
+    payload.repositoryOrigin !== policy.repository.origin ||
+    !COMMIT_OID.test(payload.baseCommit) ||
+    payload.baseCommit !== options.expectedBase ||
+    !COMMIT_OID.test(payload.policyBlob) ||
+    payload.policyBlob !== options.expectedPolicyBlob ||
+    payload.maxUses !== policy.maxUses ||
+    !Array.isArray(payload.allowedPaths) ||
+    payload.allowedPaths.length === 0 ||
+    !validReason(payload.reason) ||
+    !policy.trustedSigners.some(({ identity }) => identity === payload.signer)
+  ) {
+    throw invalidGrant('Maintainer grant does not match its trusted binding.');
+  }
+
+  try {
+    assertChangeId(payload.changeId);
+    const normalized = payload.allowedPaths.map(normalizeExactRepositoryPath);
+    if (
+      normalized.some(
+        (value, index) => value !== payload.allowedPaths[index],
+      ) ||
+      !isSortedUnique(normalized) ||
+      normalized.some((filePath) => !isAuthorityPathEligible(policy, filePath))
+    ) {
+      throw new Error('invalid paths');
+    }
+  } catch {
+    throw invalidGrant('Maintainer grant contains invalid exact paths.');
+  }
+
+  const issuedAt = exactTimestamp(payload.issuedAt);
+  const expiresAt = exactTimestamp(payload.expiresAt);
+  const now = options.now.getTime();
+  if (
+    issuedAt === undefined ||
+    expiresAt === undefined ||
+    issuedAt > expiresAt ||
+    expiresAt - issuedAt > policy.maxTtlMinutes * 60_000 ||
+    issuedAt > now + 30_000
+  ) {
+    throw invalidGrant('Maintainer grant has invalid time bounds.');
+  }
+  if (!options.allowExpired && expiresAt < now) {
+    throw workflowError(
+      'MAINTAINER_GRANT_EXPIRED',
+      'Maintainer grant has expired.',
+      ExitCode.staleState,
+    );
+  }
+}
+
+export function assertGrantPathsEligible(
+  repositoryRoot: string,
+  requestedPaths: string[],
+  policy: MaintainerPolicy,
+): string[] {
+  let paths: string[];
+  try {
+    paths = requestedPaths.map(normalizeExactRepositoryPath);
+  } catch {
+    throw invalidGrantPath();
+  }
+  if (paths.length === 0 || !isSortedUnique(paths)) {
+    throw invalidGrantPath();
+  }
+
+  const tracked = runGit(repositoryRoot, ['ls-files', '--cached', '-z', '--'])
+    .split('\0')
+    .filter(Boolean);
+  const caseFolded = new Map<string, string[]>();
+  for (const trackedPath of tracked) {
+    const key = trackedPath.toLocaleLowerCase('en-US');
+    caseFolded.set(key, [...(caseFolded.get(key) ?? []), trackedPath]);
+  }
+
+  for (const filePath of paths) {
+    const candidates =
+      caseFolded.get(filePath.toLocaleLowerCase('en-US')) ?? [];
+    const absolute = path.join(repositoryRoot, filePath);
+    const stats = fs.lstatSync(absolute, { throwIfNoEntry: false });
+    try {
+      assertPolicyPathInsideRepository(repositoryRoot, filePath);
+    } catch {
+      throw invalidGrantPath(filePath);
+    }
+    if (
+      candidates.length !== 1 ||
+      candidates[0] !== filePath ||
+      !stats?.isFile() ||
+      stats.isSymbolicLink() ||
+      fs.realpathSync(absolute) !==
+        path.join(fs.realpathSync(repositoryRoot), filePath) ||
+      !isAuthorityPathEligible(policy, filePath)
+    ) {
+      throw invalidGrantPath(filePath);
+    }
+  }
+  return paths;
+}
+
+function exactTimestamp(value: string): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString() === value
+    ? time
+    : undefined;
+}
+
+function validReason(value: string): boolean {
+  return (
+    typeof value === 'string' &&
+    value.length >= 12 &&
+    value.length <= 500 &&
+    value.trim() === value &&
+    ![...value].some((character) => {
+      const code = character.codePointAt(0) ?? 0;
+      return code <= 31 || (code >= 127 && code <= 159);
+    })
+  );
+}
+
+function isSortedUnique(values: string[]): boolean {
+  const sorted = [...new Set(values)].sort();
+  return (
+    values.length === sorted.length && values.every((v, i) => v === sorted[i])
+  );
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((v, i) => v === expected[i])
+  );
+}
+
+function invalidGrant(message: string) {
+  return workflowError('MAINTAINER_GRANT_INVALID', message, ExitCode.guard);
+}
+
+function invalidGrantPath(filePath?: string) {
+  return workflowError(
+    'MAINTAINER_GRANT_PATH_INVALID',
+    'Maintainer grant paths must be exact tracked eligible regular files.',
+    ExitCode.guard,
+    filePath ? { details: { path: filePath } } : {},
+  );
+}

--- a/packages/workflow-engine/src/maintainer-grant.ts
+++ b/packages/workflow-engine/src/maintainer-grant.ts
@@ -15,6 +15,10 @@ import {
   type MaintainerSignerProvider,
 } from './maintainer-signer.ts';
 import {
+  maintainerGrantStorePaths,
+  storeAvailableMaintainerGrant,
+} from './maintainer-store.ts';
+import {
   assertChangeId,
   assertPolicyPathInsideRepository,
   normalizeExactRepositoryPath,
@@ -119,6 +123,68 @@ export function canonicalGrantEnvelope(
   })}\n`;
 }
 
+export function assertMaintainerGrantId(requestedGrantId: string): string {
+  if (
+    typeof requestedGrantId !== 'string' ||
+    !GRANT_ID.test(requestedGrantId)
+  ) {
+    throw invalidGrant('Maintainer grant ID is invalid.');
+  }
+  return requestedGrantId;
+}
+
+export function parseMaintainerGrantEnvelope(
+  raw: string,
+): MaintainerGrantEnvelope {
+  try {
+    if (typeof raw !== 'string' || raw.length > 32_768) {
+      throw new Error('invalid envelope size');
+    }
+    const value = JSON.parse(raw) as unknown;
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      Array.isArray(value) ||
+      !hasExactKeys(value as Record<string, unknown>, ['payload', 'signature'])
+    ) {
+      throw new Error('invalid envelope');
+    }
+    const candidate = value as Record<string, unknown>;
+    if (
+      typeof candidate.payload !== 'object' ||
+      candidate.payload === null ||
+      Array.isArray(candidate.payload) ||
+      !hasExactKeys(
+        candidate.payload as Record<string, unknown>,
+        PAYLOAD_KEYS,
+      ) ||
+      typeof candidate.signature !== 'string'
+    ) {
+      throw new Error('invalid envelope fields');
+    }
+    const envelope = {
+      payload: candidate.payload as MaintainerGrantPayload,
+      signature: candidate.signature,
+    };
+    assertArmoredSshSignature(envelope.signature);
+    assertMaintainerGrantId(envelope.payload.grantId);
+    if (canonicalGrantEnvelope(envelope) !== raw) {
+      throw new Error('non-canonical envelope');
+    }
+    return envelope;
+  } catch (error) {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'MAINTAINER_SIGNATURE_INVALID'
+    ) {
+      throw error;
+    }
+    throw invalidGrant('Maintainer grant envelope is invalid.');
+  }
+}
+
 export function issueMaintainerGrant(
   cwd: string,
   request: MaintainerGrantRequest,
@@ -173,13 +239,8 @@ export function issueMaintainerGrant(
     throw invalidGrant('Maintainer grant ID is invalid.');
   }
   const tagRef = `${policy.auditTagPrefix}${grantId}`;
-  const availableDirectory = path.join(
-    repository.gitCommonDirectory,
-    'workflow-engine',
-    'maintainer-grants',
-    'available',
-  );
-  const availableTokenPath = path.join(availableDirectory, `${grantId}.json`);
+  const storePaths = maintainerGrantStorePaths(repository.gitCommonDirectory);
+  const availableTokenPath = path.join(storePaths.available, `${grantId}.json`);
   if (
     fs.existsSync(availableTokenPath) ||
     runGit(
@@ -236,8 +297,7 @@ export function issueMaintainerGrant(
     signerIdentity,
   );
   try {
-    ensurePrivateDirectory(availableDirectory);
-    writeNewPrivateFile(availableTokenPath, canonicalEnvelope);
+    storeAvailableMaintainerGrant(repository.gitCommonDirectory, envelope);
   } catch (error) {
     runGit(repository.repositoryRoot, ['update-ref', '-d', tagRef, tagObject]);
     throw error;
@@ -482,58 +542,6 @@ function createAuditTag(
 
 function policyTagPrefixLength(tagRef: string): number {
   return tagRef.lastIndexOf('/') + 1;
-}
-
-function ensurePrivateDirectory(directory: string): void {
-  const grantsDirectory = path.dirname(directory);
-  for (const current of [grantsDirectory, directory]) {
-    fs.mkdirSync(current, { recursive: true, mode: 0o700 });
-    const stats = fs.lstatSync(current);
-    if (!stats.isDirectory() || stats.isSymbolicLink()) {
-      throw workflowError(
-        'MAINTAINER_GRANT_STORE_UNSAFE',
-        'Maintainer grant storage is not a private regular directory.',
-        ExitCode.unsafeEnvironment,
-      );
-    }
-    fs.chmodSync(current, 0o700);
-  }
-}
-
-function writeNewPrivateFile(filePath: string, content: string): void {
-  let descriptor: number | undefined;
-  let created = false;
-  try {
-    descriptor = fs.openSync(
-      filePath,
-      fs.constants.O_CREAT |
-        fs.constants.O_EXCL |
-        fs.constants.O_WRONLY |
-        fs.constants.O_NOFOLLOW,
-      0o600,
-    );
-    created = true;
-    fs.writeFileSync(descriptor, content, 'utf8');
-    fs.fsyncSync(descriptor);
-    fs.closeSync(descriptor);
-    descriptor = undefined;
-  } catch (error) {
-    if (descriptor !== undefined) {
-      fs.closeSync(descriptor);
-    }
-    if (created) {
-      fs.rmSync(filePath, { force: true });
-    }
-    if (
-      error &&
-      typeof error === 'object' &&
-      'code' in error &&
-      error.code === 'EEXIST'
-    ) {
-      throw grantExists(path.basename(filePath, '.json'));
-    }
-    throw error;
-  }
 }
 
 function validReason(value: string): boolean {

--- a/packages/workflow-engine/src/maintainer-grant.ts
+++ b/packages/workflow-engine/src/maintainer-grant.ts
@@ -1,12 +1,19 @@
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { ExitCode, workflowError } from './errors.ts';
-import { runGit } from './git.ts';
+import { discoverRepository, runGit, runGitWithEnvironment } from './git.ts';
 import {
   isAuthorityPathEligible,
+  parseMaintainerPolicy,
   type MaintainerPolicy,
 } from './maintainer-policy.ts';
+import {
+  createInteractiveSshSigner,
+  type MaintainerSignerProvider,
+} from './maintainer-signer.ts';
 import {
   assertChangeId,
   assertPolicyPathInsideRepository,
@@ -48,6 +55,33 @@ export type MaintainerGrantPayload = {
   signer: string;
 };
 
+export type MaintainerGrantEnvelope = {
+  payload: MaintainerGrantPayload;
+  signature: string;
+};
+
+export type MaintainerGrantRequest = {
+  changeId: string;
+  paths: string[];
+  reason: string;
+  ttlMinutes?: number;
+  maxUses?: number;
+};
+
+export type MaintainerGrantIssueOptions = {
+  now?: Date;
+  grantId?: string;
+  signer?: MaintainerSignerProvider;
+};
+
+export type MaintainerGrantIssueResult = {
+  grantId: string;
+  tagRef: string;
+  publishCommand: string;
+  availableTokenPath: string;
+  envelope: MaintainerGrantEnvelope;
+};
+
 export type GrantValidationOptions = {
   now: Date;
   expectedBase: string;
@@ -71,6 +105,151 @@ export function canonicalGrantPayload(payload: MaintainerGrantPayload): string {
     reason: payload.reason,
     signer: payload.signer,
   })}\n`;
+}
+
+export function canonicalGrantEnvelope(
+  envelope: MaintainerGrantEnvelope,
+): string {
+  const canonicalPayload = JSON.parse(
+    canonicalGrantPayload(envelope.payload),
+  ) as MaintainerGrantPayload;
+  return `${JSON.stringify({
+    payload: canonicalPayload,
+    signature: envelope.signature,
+  })}\n`;
+}
+
+export function issueMaintainerGrant(
+  cwd: string,
+  request: MaintainerGrantRequest,
+  options: MaintainerGrantIssueOptions = {},
+): MaintainerGrantIssueResult {
+  const repository = discoverRepository(cwd);
+  if (repository.statusEntries.length > 0) {
+    throw workflowError(
+      'MAINTAINER_GRANT_DIRTY_WORKTREE',
+      'Maintainer grants can be issued only from a clean worktree.',
+      ExitCode.conflict,
+    );
+  }
+
+  const policy = loadBasePolicy(repository.repositoryRoot, repository.head);
+  const origin = runGit(repository.repositoryRoot, [
+    'remote',
+    'get-url',
+    'origin',
+  ]).trim();
+  if (origin !== policy.repository.origin) {
+    throw workflowError(
+      'MAINTAINER_REPOSITORY_MISMATCH',
+      'The repository origin does not match the trusted maintainer policy.',
+      ExitCode.guard,
+    );
+  }
+
+  const requestedPaths = normalizeRequestedPaths(request.paths);
+  const allowedPaths = assertGrantPathsEligible(
+    repository.repositoryRoot,
+    requestedPaths,
+    policy,
+  );
+  const ttlMinutes = request.ttlMinutes ?? policy.maxTtlMinutes;
+  const maxUses = request.maxUses ?? policy.maxUses;
+  if (
+    !Number.isInteger(ttlMinutes) ||
+    ttlMinutes < 1 ||
+    ttlMinutes > policy.maxTtlMinutes ||
+    maxUses !== 1
+  ) {
+    throw invalidGrant('Maintainer grant bounds exceed trusted policy.');
+  }
+
+  const now = options.now ? new Date(options.now) : new Date();
+  if (!Number.isFinite(now.getTime())) {
+    throw invalidGrant('Maintainer grant issue time is invalid.');
+  }
+  const grantId = options.grantId ?? crypto.randomUUID();
+  if (!GRANT_ID.test(grantId)) {
+    throw invalidGrant('Maintainer grant ID is invalid.');
+  }
+  const tagRef = `${policy.auditTagPrefix}${grantId}`;
+  const availableDirectory = path.join(
+    repository.gitCommonDirectory,
+    'workflow-engine',
+    'maintainer-grants',
+    'available',
+  );
+  const availableTokenPath = path.join(availableDirectory, `${grantId}.json`);
+  if (
+    fs.existsSync(availableTokenPath) ||
+    runGit(
+      repository.repositoryRoot,
+      ['rev-parse', '--verify', tagRef],
+      true,
+    ).trim()
+  ) {
+    throw grantExists(grantId);
+  }
+
+  const signer =
+    options.signer ??
+    createInteractiveSshSigner(repository.repositoryRoot, policy);
+  signer.assertHumanPresent();
+  const signerIdentity = signer.identity();
+  const policyBlob = runGit(repository.repositoryRoot, [
+    'rev-parse',
+    `${repository.head}:workflow/maintainer-policy.json`,
+  ]).trim();
+  const payload: MaintainerGrantPayload = {
+    version: 1,
+    grantId,
+    repositoryId: policy.repository.id,
+    repositoryOrigin: policy.repository.origin,
+    baseCommit: repository.head,
+    policyBlob,
+    changeId: request.changeId,
+    allowedPaths,
+    issuedAt: now.toISOString(),
+    expiresAt: new Date(now.getTime() + ttlMinutes * 60_000).toISOString(),
+    maxUses: 1,
+    reason: request.reason,
+    signer: signerIdentity,
+  };
+  validateGrantPayload(payload, policy, {
+    now,
+    expectedBase: repository.head,
+    expectedPolicyBlob: policyBlob,
+  });
+
+  const canonicalPayload = canonicalGrantPayload(payload);
+  const signature = signer.sign(canonicalPayload);
+  assertArmoredSshSignature(signature);
+  signer.verify(canonicalPayload, signature, signerIdentity);
+  const envelope = { payload, signature };
+  const canonicalEnvelope = canonicalGrantEnvelope(envelope);
+
+  const tagObject = createAuditTag(
+    repository.repositoryRoot,
+    repository.head,
+    tagRef,
+    canonicalEnvelope,
+    signerIdentity,
+  );
+  try {
+    ensurePrivateDirectory(availableDirectory);
+    writeNewPrivateFile(availableTokenPath, canonicalEnvelope);
+  } catch (error) {
+    runGit(repository.repositoryRoot, ['update-ref', '-d', tagRef, tagObject]);
+    throw error;
+  }
+
+  return {
+    grantId,
+    tagRef,
+    publishCommand: `git push origin ${tagRef}:${tagRef}`,
+    availableTokenPath,
+    envelope,
+  };
 }
 
 export function validateGrantPayload(
@@ -199,6 +378,164 @@ function exactTimestamp(value: string): number | undefined {
     : undefined;
 }
 
+function loadBasePolicy(
+  repositoryRoot: string,
+  baseCommit: string,
+): MaintainerPolicy {
+  try {
+    return parseMaintainerPolicy(
+      JSON.parse(
+        runGit(repositoryRoot, [
+          'show',
+          `${baseCommit}:workflow/maintainer-policy.json`,
+        ]),
+      ),
+    );
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error) {
+      throw error;
+    }
+    throw workflowError(
+      'MAINTAINER_POLICY_INVALID',
+      'The base commit does not contain a valid maintainer policy.',
+      ExitCode.guard,
+    );
+  }
+}
+
+function normalizeRequestedPaths(requestedPaths: string[]): string[] {
+  if (!Array.isArray(requestedPaths)) {
+    throw invalidGrantPath();
+  }
+  let normalized: string[];
+  try {
+    normalized = requestedPaths.map(normalizeExactRepositoryPath).sort();
+  } catch {
+    throw invalidGrantPath();
+  }
+  if (normalized.length !== new Set(normalized).size) {
+    throw invalidGrantPath();
+  }
+  return normalized;
+}
+
+function assertArmoredSshSignature(signature: string): void {
+  if (
+    typeof signature !== 'string' ||
+    signature.length > 16_384 ||
+    signature.includes('\r') ||
+    !/^-----BEGIN SSH SIGNATURE-----\n(?:[A-Za-z0-9+/=]+\n)+-----END SSH SIGNATURE-----\n$/.test(
+      signature,
+    )
+  ) {
+    throw workflowError(
+      'MAINTAINER_SIGNATURE_INVALID',
+      'The maintainer grant SSH signature is invalid.',
+      ExitCode.verification,
+    );
+  }
+}
+
+function createAuditTag(
+  repositoryRoot: string,
+  baseCommit: string,
+  tagRef: string,
+  message: string,
+  signerIdentity: string,
+): string {
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-grant-tag-'),
+  );
+  fs.chmodSync(temporaryDirectory, 0o700);
+  const messagePath = path.join(temporaryDirectory, 'message');
+  try {
+    fs.writeFileSync(messagePath, message, { encoding: 'utf8', mode: 0o600 });
+    const shortName = tagRef.slice('refs/tags/'.length);
+    runGitWithEnvironment(
+      repositoryRoot,
+      [
+        'tag',
+        '--annotate',
+        '--cleanup=verbatim',
+        '--file',
+        messagePath,
+        shortName,
+        baseCommit,
+      ],
+      {
+        GIT_COMMITTER_NAME: signerIdentity,
+        GIT_COMMITTER_EMAIL: 'workflow-maintainer@users.noreply.github.com',
+      },
+    );
+    return runGit(repositoryRoot, ['rev-parse', `${tagRef}^{tag}`]).trim();
+  } catch (error) {
+    if (
+      runGit(repositoryRoot, ['rev-parse', '--verify', tagRef], true).trim()
+    ) {
+      throw grantExists(tagRef.slice(policyTagPrefixLength(tagRef)));
+    }
+    throw error;
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function policyTagPrefixLength(tagRef: string): number {
+  return tagRef.lastIndexOf('/') + 1;
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  const grantsDirectory = path.dirname(directory);
+  for (const current of [grantsDirectory, directory]) {
+    fs.mkdirSync(current, { recursive: true, mode: 0o700 });
+    const stats = fs.lstatSync(current);
+    if (!stats.isDirectory() || stats.isSymbolicLink()) {
+      throw workflowError(
+        'MAINTAINER_GRANT_STORE_UNSAFE',
+        'Maintainer grant storage is not a private regular directory.',
+        ExitCode.unsafeEnvironment,
+      );
+    }
+    fs.chmodSync(current, 0o700);
+  }
+}
+
+function writeNewPrivateFile(filePath: string, content: string): void {
+  let descriptor: number | undefined;
+  let created = false;
+  try {
+    descriptor = fs.openSync(
+      filePath,
+      fs.constants.O_CREAT |
+        fs.constants.O_EXCL |
+        fs.constants.O_WRONLY |
+        fs.constants.O_NOFOLLOW,
+      0o600,
+    );
+    created = true;
+    fs.writeFileSync(descriptor, content, 'utf8');
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+  } catch (error) {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+    if (created) {
+      fs.rmSync(filePath, { force: true });
+    }
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'EEXIST'
+    ) {
+      throw grantExists(path.basename(filePath, '.json'));
+    }
+    throw error;
+  }
+}
+
 function validReason(value: string): boolean {
   return (
     typeof value === 'string' &&
@@ -230,6 +567,14 @@ function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
 
 function invalidGrant(message: string) {
   return workflowError('MAINTAINER_GRANT_INVALID', message, ExitCode.guard);
+}
+
+function grantExists(grantId: string) {
+  return workflowError(
+    'MAINTAINER_GRANT_EXISTS',
+    `Maintainer grant ${grantId} already has local state or an audit tag.`,
+    ExitCode.conflict,
+  );
 }
 
 function invalidGrantPath(filePath?: string) {

--- a/packages/workflow-engine/src/maintainer-policy.ts
+++ b/packages/workflow-engine/src/maintainer-policy.ts
@@ -1,0 +1,223 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isRecord, isStringArray } from './contract-values.ts';
+import { ExitCode, workflowError } from './errors.ts';
+import { matchesAllowedPath, normalizePolicyPath } from './paths.ts';
+
+const CHECK_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SIGNER_ID = /^[a-zA-Z0-9][a-zA-Z0-9._@+-]{0,127}$/;
+const SSH_PUBLIC_KEY =
+  /^ssh-(?:ed25519|ed25519-sk|rsa|ecdsa-[^ ]+) [A-Za-z0-9+/]+={0,2}$/;
+const SSH_FINGERPRINT = /^SHA256:[A-Za-z0-9+/]{20,}$/;
+const POLICY_KEYS = [
+  'schemaVersion',
+  'repository',
+  'phase',
+  'auditTagPrefix',
+  'signatureNamespace',
+  'maxTtlMinutes',
+  'maxUses',
+  'bootstrapEligiblePaths',
+  'sealedImmutablePaths',
+  'requiredChecks',
+  'trustedSigners',
+];
+
+export type TrustedMaintainerSigner = {
+  identity: string;
+  publicKey: string;
+  fingerprint: string;
+};
+
+export type MaintainerPolicy = {
+  schemaVersion: 1;
+  repository: { id: string; origin: string };
+  phase: 'bootstrap' | 'sealed';
+  auditTagPrefix: string;
+  signatureNamespace: string;
+  maxTtlMinutes: 30;
+  maxUses: 1;
+  bootstrapEligiblePaths: string[];
+  sealedImmutablePaths: string[];
+  requiredChecks: string[];
+  trustedSigners: TrustedMaintainerSigner[];
+};
+
+export function loadMaintainerPolicy(repositoryRoot: string): MaintainerPolicy {
+  const policyPath = path.join(
+    repositoryRoot,
+    'workflow/maintainer-policy.json',
+  );
+  let value: unknown;
+  try {
+    value = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+  } catch (error) {
+    throw invalidPolicy('Unable to read workflow/maintainer-policy.json.', {
+      cause: error instanceof Error ? error.message : String(error),
+    });
+  }
+  return parseMaintainerPolicy(value);
+}
+
+export function parseMaintainerPolicy(value: unknown): MaintainerPolicy {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, POLICY_KEYS) ||
+    value.schemaVersion !== 1 ||
+    !isRecord(value.repository) ||
+    !hasExactKeys(value.repository, ['id', 'origin']) ||
+    typeof value.repository.id !== 'string' ||
+    !/^github:[A-Za-z0-9_-]+$/.test(value.repository.id) ||
+    typeof value.repository.origin !== 'string' ||
+    !/^https:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\.git$/.test(
+      value.repository.origin,
+    ) ||
+    (value.phase !== 'bootstrap' && value.phase !== 'sealed') ||
+    typeof value.auditTagPrefix !== 'string' ||
+    !/^refs\/tags\/[a-z0-9][a-z0-9-]*\/$/.test(value.auditTagPrefix) ||
+    value.signatureNamespace !== 'expense-app.workflow.maintainer-grant.v1' ||
+    value.maxTtlMinutes !== 30 ||
+    value.maxUses !== 1 ||
+    !isStringArray(value.bootstrapEligiblePaths) ||
+    !isStringArray(value.sealedImmutablePaths) ||
+    !isStringArray(value.requiredChecks) ||
+    !Array.isArray(value.trustedSigners) ||
+    value.trustedSigners.length === 0
+  ) {
+    throw invalidPolicy('Maintainer policy does not match schema version 1.');
+  }
+
+  const bootstrapEligiblePaths = value.bootstrapEligiblePaths;
+  const sealedImmutablePaths = value.sealedImmutablePaths;
+  const requiredChecks = value.requiredChecks;
+
+  assertSortedUnique(bootstrapEligiblePaths, 'bootstrap paths');
+  assertSortedUnique(sealedImmutablePaths, 'sealed paths');
+  assertSortedUnique(requiredChecks, 'required checks');
+
+  try {
+    bootstrapEligiblePaths.forEach(normalizePolicyPath);
+    sealedImmutablePaths.forEach(normalizePolicyPath);
+  } catch {
+    throw invalidPolicy(
+      'Maintainer policy contains an invalid authority path.',
+    );
+  }
+  if (
+    requiredChecks.length === 0 ||
+    requiredChecks.some((checkId) => !CHECK_ID.test(checkId))
+  ) {
+    throw invalidPolicy('Maintainer policy contains invalid required checks.');
+  }
+  if (
+    sealedImmutablePaths.some(
+      (immutablePath) =>
+        !bootstrapEligiblePaths.some((eligiblePath) =>
+          matchesAllowedPath(immutablePath, eligiblePath),
+        ),
+    )
+  ) {
+    throw invalidPolicy(
+      'Every sealed immutable path must be bootstrap-eligible.',
+    );
+  }
+
+  const signers = value.trustedSigners.map(parseSigner);
+  assertSortedUnique(
+    signers.map(({ identity }) => identity),
+    'trusted signer identities',
+  );
+  if (
+    new Set(signers.map(({ publicKey }) => publicKey)).size !==
+      signers.length ||
+    new Set(signers.map(({ fingerprint }) => fingerprint)).size !==
+      signers.length
+  ) {
+    throw invalidPolicy('Trusted maintainer signer keys must be unique.');
+  }
+
+  return {
+    schemaVersion: 1,
+    repository: {
+      id: value.repository.id,
+      origin: value.repository.origin,
+    },
+    phase: value.phase,
+    auditTagPrefix: value.auditTagPrefix,
+    signatureNamespace: value.signatureNamespace,
+    maxTtlMinutes: 30,
+    maxUses: 1,
+    bootstrapEligiblePaths: [...bootstrapEligiblePaths],
+    sealedImmutablePaths: [...sealedImmutablePaths],
+    requiredChecks: [...requiredChecks],
+    trustedSigners: signers,
+  };
+}
+
+export function isAuthorityPathEligible(
+  policy: MaintainerPolicy,
+  filePath: string,
+): boolean {
+  return (
+    policy.bootstrapEligiblePaths.some((eligible) =>
+      matchesAllowedPath(filePath, eligible),
+    ) &&
+    (policy.phase !== 'sealed' ||
+      !policy.sealedImmutablePaths.some((immutable) =>
+        matchesAllowedPath(filePath, immutable),
+      ))
+  );
+}
+
+function parseSigner(value: unknown): TrustedMaintainerSigner {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ['identity', 'publicKey', 'fingerprint']) ||
+    typeof value.identity !== 'string' ||
+    !SIGNER_ID.test(value.identity) ||
+    typeof value.publicKey !== 'string' ||
+    !SSH_PUBLIC_KEY.test(value.publicKey) ||
+    typeof value.fingerprint !== 'string' ||
+    !SSH_FINGERPRINT.test(value.fingerprint)
+  ) {
+    throw invalidPolicy(
+      'Maintainer policy contains an invalid trusted signer.',
+    );
+  }
+  return {
+    identity: value.identity,
+    publicKey: value.publicKey,
+    fingerprint: value.fingerprint,
+  };
+}
+
+function assertSortedUnique(values: string[], label: string): void {
+  const sorted = [...new Set(values)].sort();
+  if (
+    values.length !== sorted.length ||
+    values.some((v, i) => v !== sorted[i])
+  ) {
+    throw invalidPolicy(
+      `Maintainer policy ${label} must be sorted and unique.`,
+    );
+  }
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}
+
+function invalidPolicy(message: string, details?: Record<string, unknown>) {
+  return workflowError(
+    'MAINTAINER_POLICY_INVALID',
+    message,
+    ExitCode.guard,
+    details ? { details } : {},
+  );
+}

--- a/packages/workflow-engine/src/maintainer-recovery.ts
+++ b/packages/workflow-engine/src/maintainer-recovery.ts
@@ -1,0 +1,748 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ExitCode, workflowError } from './errors.ts';
+import {
+  authorityCommitMessage,
+  commitChangedPaths,
+  commitFacts,
+  rollbackExactStaging,
+  updateManagedRef,
+} from './git-transitions.ts';
+import { discoverRepository, runGit } from './git.ts';
+import { parseMaintainerPolicy } from './maintainer-policy.ts';
+import {
+  failAuthoritySession,
+  markAuthoritySessionCommitted,
+  readAuthoritySession,
+  type AuthoritySession,
+} from './maintainer-session.ts';
+import {
+  consumeMaintainerReservationUnderLifecycleLock,
+  inspectMaintainerGrants,
+  maintainerGrantStorePaths,
+} from './maintainer-store.ts';
+import { parseManagedTrailers } from './managed-trailers.ts';
+import { assertSessionId } from './paths.ts';
+import { withRepositoryLifecycleOperation } from './session-store.ts';
+
+export type AuthorityCommitJournalState =
+  'preparing' | 'commit-created' | 'ref-updated' | 'consumed' | 'revoked';
+
+export type AuthorityCommitJournal = {
+  schemaVersion: 1;
+  state: AuthorityCommitJournalState;
+  sessionId: string;
+  grantId: string;
+  changeId: string;
+  repositoryRoot: string;
+  branch: string;
+  baseCommit: string;
+  expectedTree: string;
+  previousIndexTree: string;
+  allowedPaths: string[];
+  subject: string;
+  messageDigest: string;
+  policyBlob: string;
+  signer: string;
+  commitHash: string | null;
+  reason: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AuthorityCommitResult = {
+  session: AuthoritySession;
+  grantId: string;
+  commitHash: string;
+  changedPaths: string[];
+  journalState: 'consumed';
+};
+
+export function beginAuthorityCommitJournal(
+  session: AuthoritySession,
+  input: {
+    expectedTree: string;
+    previousIndexTree: string;
+    changedPaths: string[];
+    subject: string;
+    now: Date;
+  },
+): AuthorityCommitJournal {
+  const timestamp = exactDate(input.now).toISOString();
+  const journal: AuthorityCommitJournal = {
+    schemaVersion: 1,
+    state: 'preparing',
+    sessionId: session.sessionId,
+    grantId: session.grantId,
+    changeId: session.changeId,
+    repositoryRoot: session.repositoryRoot,
+    branch: session.branch,
+    baseCommit: session.baseCommit,
+    expectedTree: assertObjectId(input.expectedTree),
+    previousIndexTree: assertObjectId(input.previousIndexTree),
+    allowedPaths: [...input.changedPaths],
+    subject: input.subject,
+    messageDigest: digest(
+      `${authorityCommitMessage(
+        input.subject,
+        session.changeId,
+        session.grantId,
+      )}\n`,
+    ),
+    policyBlob: assertObjectId(session.policyBlob),
+    signer: session.signer,
+    commitHash: null,
+    reason: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+  writeJournal(session.gitCommonDirectory, journal, true);
+  return journal;
+}
+
+export function recordAuthorityCommitCreated(
+  gitCommonDirectory: string,
+  journal: AuthorityCommitJournal,
+  commitHash: string,
+  now: Date,
+): AuthorityCommitJournal {
+  return transitionJournal(gitCommonDirectory, journal, 'preparing', {
+    state: 'commit-created',
+    commitHash: assertObjectId(commitHash),
+    updatedAt: exactDate(now).toISOString(),
+  });
+}
+
+export function recordAuthorityRefUpdated(
+  gitCommonDirectory: string,
+  journal: AuthorityCommitJournal,
+  now: Date,
+): AuthorityCommitJournal {
+  return transitionJournal(gitCommonDirectory, journal, 'commit-created', {
+    state: 'ref-updated',
+    updatedAt: exactDate(now).toISOString(),
+  });
+}
+
+export function recoverAuthorityCommit(
+  cwd: string,
+  requestedSessionId: string,
+  now = new Date(),
+): AuthorityCommitResult {
+  const session = readAuthoritySession(cwd, requestedSessionId);
+  const journal = readAuthorityCommitJournal(
+    session.gitCommonDirectory,
+    session.sessionId,
+  );
+  assertJournalMatchesSession(journal, session);
+
+  if (journal.state === 'revoked') {
+    throw recoveryError(
+      'AUTHORITY_RECOVERY_REVOKED',
+      'The authority transaction was terminally revoked.',
+    );
+  }
+  if (journal.state === 'preparing') {
+    revokePreparingTransaction(cwd, session, journal, now);
+  }
+
+  try {
+    return withRepositoryLifecycleOperation(
+      maintainerGrantStorePaths(session.gitCommonDirectory).runtime,
+      (assertOwned) => {
+        assertOwned();
+        const currentSession = readAuthoritySession(cwd, session.sessionId);
+        assertJournalMatchesSession(journal, currentSession);
+        const currentJournal = readAuthorityCommitJournal(
+          session.gitCommonDirectory,
+          session.sessionId,
+        );
+        if (currentJournal.state === 'consumed') {
+          return finalizeConsumed(cwd, currentSession, currentJournal, now);
+        }
+        if (
+          currentJournal.state !== 'commit-created' &&
+          currentJournal.state !== 'ref-updated'
+        ) {
+          throw recoveryError(
+            'AUTHORITY_JOURNAL_DIVERGED',
+            'Authority journal state changed during recovery.',
+          );
+        }
+        const commitHash = requireCommitHash(currentJournal);
+        verifyJournaledCommit(cwd, currentSession, currentJournal, commitHash);
+        const git = discoverRepository(cwd);
+        const indexTree = runGit(git.repositoryRoot, ['write-tree']).trim();
+        if (indexTree !== currentJournal.expectedTree) {
+          throw recoveryError(
+            'AUTHORITY_RECOVERY_INDEX_DIVERGED',
+            'The Git index differs from the journaled authority tree.',
+          );
+        }
+        let advanced = currentJournal;
+        if (git.head === currentJournal.baseCommit) {
+          updateManagedRef(
+            git.repositoryRoot,
+            currentJournal.baseCommit,
+            commitHash,
+          );
+        } else if (git.head !== commitHash) {
+          throw recoveryError(
+            'AUTHORITY_RECOVERY_REF_DIVERGED',
+            'The branch no longer points to the journaled base or commit.',
+          );
+        }
+        if (advanced.state === 'commit-created') {
+          advanced = recordAuthorityRefUpdated(
+            session.gitCommonDirectory,
+            advanced,
+            now,
+          );
+        }
+        assertOwned();
+        consumeMaintainerReservationUnderLifecycleLock(
+          session.gitCommonDirectory,
+          session.grantId,
+          session.sessionId,
+          commitHash,
+          now,
+        );
+        const consumed = transitionJournal(
+          session.gitCommonDirectory,
+          advanced,
+          'ref-updated',
+          {
+            state: 'consumed',
+            updatedAt: exactDate(now).toISOString(),
+          },
+        );
+        const committed = markAuthoritySessionCommitted(
+          cwd,
+          currentSession,
+          commitHash,
+          now,
+        );
+        return result(committed, consumed, commitHash);
+      },
+      { allowMaintainerGrantId: session.grantId },
+    );
+  } catch (error) {
+    const inspection = inspectMaintainerGrants(
+      session.gitCommonDirectory,
+      session.grantId,
+    )[0];
+    if (
+      inspection?.state === 'consumed' &&
+      inspection.commitHash === journal.commitHash
+    ) {
+      throw recoveryError(
+        'AUTHORITY_RECOVERY_FINALIZATION_REQUIRED',
+        'The grant is consumed but journal finalization must be retried.',
+      );
+    }
+    revokeAmbiguousTransaction(session, journal, error, now);
+    throw error;
+  }
+}
+
+export function readAuthorityCommitJournal(
+  gitCommonDirectory: string,
+  requestedSessionId: string,
+): AuthorityCommitJournal {
+  const sessionId = assertSessionId(requestedSessionId);
+  const journalPath = path.join(
+    maintainerGrantStorePaths(gitCommonDirectory).journals,
+    `${sessionId}.json`,
+  );
+  const stats = fs.lstatSync(journalPath, { throwIfNoEntry: false });
+  if (
+    !stats?.isFile() ||
+    stats.isSymbolicLink() ||
+    stats.nlink !== 1 ||
+    (stats.mode & 0o777) !== 0o600
+  ) {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_INVALID',
+      'Authority recovery journal is missing or unsafe.',
+    );
+  }
+  try {
+    const raw = fs.readFileSync(journalPath, 'utf8');
+    const value = JSON.parse(raw) as unknown;
+    if (
+      !isJournal(value) ||
+      raw !== `${JSON.stringify(value)}\n` ||
+      value.sessionId !== sessionId
+    ) {
+      throw new Error('invalid journal');
+    }
+    return value;
+  } catch {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_INVALID',
+      'Authority recovery journal is malformed.',
+    );
+  }
+}
+
+export function verifyCreatedAuthorityCommit(
+  cwd: string,
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+): void {
+  assertJournalMatchesSession(journal, session);
+  if (journal.state !== 'commit-created') {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_COMMIT_MISSING',
+      'Authority commit verification requires a created commit object.',
+    );
+  }
+  verifyJournaledCommit(cwd, session, journal, requireCommitHash(journal));
+}
+
+function finalizeConsumed(
+  cwd: string,
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+  now: Date,
+): AuthorityCommitResult {
+  const commitHash = requireCommitHash(journal);
+  verifyJournaledCommit(cwd, session, journal, commitHash);
+  const terminal = inspectMaintainerGrants(
+    session.gitCommonDirectory,
+    session.grantId,
+  )[0];
+  if (
+    terminal?.state !== 'consumed' ||
+    terminal.commitHash !== commitHash ||
+    terminal.reservationSessionId !== session.sessionId
+  ) {
+    throw recoveryError(
+      'AUTHORITY_TERMINAL_STATE_DIVERGED',
+      'Consumed journal and terminal grant state do not match.',
+    );
+  }
+  const committed =
+    session.state === 'committed'
+      ? session
+      : markAuthoritySessionCommitted(cwd, session, commitHash, now);
+  if (committed.commitHash !== commitHash) {
+    throw recoveryError(
+      'AUTHORITY_SESSION_DIVERGED',
+      'Committed authority session references another commit.',
+    );
+  }
+  return result(committed, journal, commitHash);
+}
+
+function verifyJournaledCommit(
+  cwd: string,
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+  commitHash: string,
+): void {
+  const git = discoverRepository(cwd);
+  if (
+    git.repositoryRealPath !== journal.repositoryRoot ||
+    git.gitCommonDirectory !== session.gitCommonDirectory ||
+    git.branch !== journal.branch
+  ) {
+    throw recoveryError(
+      'AUTHORITY_RECOVERY_REPOSITORY_DIVERGED',
+      'Authority recovery repository or branch differs from the journal.',
+    );
+  }
+  const facts = commitFacts(git.repositoryRoot, commitHash);
+  const expectedMessage = authorityCommitMessage(
+    journal.subject,
+    journal.changeId,
+    journal.grantId,
+  );
+  const trailers = parseManagedTrailers(facts.message);
+  if (
+    JSON.stringify(facts.parents) !== JSON.stringify([journal.baseCommit]) ||
+    facts.tree !== journal.expectedTree ||
+    facts.message !== `${expectedMessage}\n` ||
+    digest(facts.message) !== journal.messageDigest ||
+    JSON.stringify(commitChangedPaths(git.repositoryRoot, commitHash)) !==
+      JSON.stringify(journal.allowedPaths) ||
+    trailers?.kind !== 'authority' ||
+    trailers.changeId !== journal.changeId ||
+    trailers.grantId !== journal.grantId
+  ) {
+    throw recoveryError(
+      'AUTHORITY_COMMIT_INVALID',
+      'The journaled commit does not match the exact authority transaction.',
+    );
+  }
+  verifyCommitSignature(git.repositoryRoot, session, commitHash);
+}
+
+function verifyCommitSignature(
+  repositoryRoot: string,
+  session: AuthoritySession,
+  commitHash: string,
+): void {
+  const policyContent = runGit(repositoryRoot, [
+    'show',
+    `${session.baseCommit}:workflow/maintainer-policy.json`,
+  ]);
+  const policy = parseMaintainerPolicy(JSON.parse(policyContent));
+  const policyBlob = runGit(repositoryRoot, [
+    'rev-parse',
+    `${session.baseCommit}:workflow/maintainer-policy.json`,
+  ]).trim();
+  const signer = policy.trustedSigners.find(
+    ({ identity }) => identity === session.signer,
+  );
+  if (!signer || policyBlob !== session.policyBlob) {
+    throw recoveryError(
+      'AUTHORITY_COMMIT_SIGNER_INVALID',
+      'The journaled signer is not trusted by the exact parent policy.',
+    );
+  }
+  const temporaryDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-authority-verify-'),
+  );
+  fs.chmodSync(temporaryDirectory, 0o700);
+  const allowedSigners = path.join(temporaryDirectory, 'allowed-signers');
+  try {
+    fs.writeFileSync(
+      allowedSigners,
+      `${signer.identity} ${signer.publicKey}\n`,
+      { mode: 0o600 },
+    );
+    const verification = runGit(repositoryRoot, [
+      '-c',
+      'gpg.format=ssh',
+      '-c',
+      `gpg.ssh.allowedSignersFile=${allowedSigners}`,
+      'show',
+      '-s',
+      '--format=%G?%x00%GS%x00%GF',
+      commitHash,
+    ]).trimEnd();
+    const [status, identity, fingerprint] = verification.split('\0');
+    if (
+      status !== 'G' ||
+      identity !== signer.identity ||
+      fingerprint !== signer.fingerprint
+    ) {
+      throw new Error('signature mismatch');
+    }
+  } catch {
+    throw recoveryError(
+      'AUTHORITY_COMMIT_SIGNATURE_INVALID',
+      'The authority commit signature is missing, invalid, or untrusted.',
+    );
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function revokePreparingTransaction(
+  cwd: string,
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+  now: Date,
+): never {
+  try {
+    withRepositoryLifecycleOperation(
+      maintainerGrantStorePaths(session.gitCommonDirectory).runtime,
+      (assertOwned) => {
+        assertOwned();
+        const git = discoverRepository(cwd);
+        const indexTree = runGit(git.repositoryRoot, ['write-tree']).trim();
+        if (
+          git.head !== journal.baseCommit ||
+          indexTree !== journal.expectedTree
+        ) {
+          throw recoveryError(
+            'AUTHORITY_RECOVERY_PREPARING_DIVERGED',
+            'Preparing transaction no longer matches its base and staged tree.',
+          );
+        }
+        rollbackExactStaging(
+          git.repositoryRoot,
+          journal.previousIndexTree,
+          journal.expectedTree,
+          new Error('authority preparing recovery'),
+        );
+        transitionJournal(session.gitCommonDirectory, journal, 'preparing', {
+          state: 'revoked',
+          reason: 'Commit object was not durably journaled',
+          updatedAt: exactDate(now).toISOString(),
+        });
+      },
+      { allowMaintainerGrantId: session.grantId },
+    );
+  } catch (error) {
+    revokeAmbiguousTransaction(session, journal, error, now);
+    throw error;
+  }
+  const error = recoveryError(
+    'AUTHORITY_RECOVERY_REVOKED',
+    'Preparing authority transaction was rolled back and revoked.',
+  );
+  failAuthoritySession(session, error, now);
+  throw error;
+}
+
+function revokeAmbiguousTransaction(
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+  cause: unknown,
+  now: Date,
+): void {
+  try {
+    const observed = readAuthorityCommitJournal(
+      session.gitCommonDirectory,
+      session.sessionId,
+    );
+    if (observed.state !== 'consumed' && observed.state !== 'revoked') {
+      transitionJournal(session.gitCommonDirectory, observed, observed.state, {
+        state: 'revoked',
+        reason:
+          cause instanceof Error ? cause.message : 'Ambiguous recovery state',
+        updatedAt: exactDate(now).toISOString(),
+      });
+    }
+  } catch {
+    // The terminal grant record remains the fail-closed authority if the
+    // private journal itself is too damaged to update safely.
+  }
+  if (session.state === 'active') {
+    failAuthoritySession(session, cause, now);
+  }
+}
+
+function transitionJournal(
+  gitCommonDirectory: string,
+  expected: AuthorityCommitJournal,
+  expectedState: AuthorityCommitJournalState,
+  update: Partial<AuthorityCommitJournal> & {
+    state: AuthorityCommitJournalState;
+    updatedAt: string;
+  },
+): AuthorityCommitJournal {
+  const current = readAuthorityCommitJournal(
+    gitCommonDirectory,
+    expected.sessionId,
+  );
+  if (
+    current.state !== expectedState ||
+    JSON.stringify(current) !== JSON.stringify(expected)
+  ) {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_DIVERGED',
+      'Authority journal changed during its transaction.',
+    );
+  }
+  const next = { ...current, ...update };
+  writeJournal(gitCommonDirectory, next, false);
+  return next;
+}
+
+function writeJournal(
+  gitCommonDirectory: string,
+  journal: AuthorityCommitJournal,
+  create: boolean,
+): void {
+  const directory = maintainerGrantStorePaths(gitCommonDirectory).journals;
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const directoryStats = fs.lstatSync(directory);
+  if (
+    !directoryStats.isDirectory() ||
+    directoryStats.isSymbolicLink() ||
+    fs.realpathSync(directory) !== path.resolve(directory)
+  ) {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_DIRECTORY_UNSAFE',
+      'Authority journal directory is unsafe.',
+    );
+  }
+  fs.chmodSync(directory, 0o700);
+  const target = path.join(directory, `${journal.sessionId}.json`);
+  const temporary = `${target}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(temporary, 'wx', 0o600);
+    fs.writeFileSync(descriptor, `${JSON.stringify(journal)}\n`, 'utf8');
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    if (create) {
+      fs.linkSync(temporary, target);
+      fs.unlinkSync(temporary);
+    } else {
+      fs.renameSync(temporary, target);
+    }
+    const directoryDescriptor = fs.openSync(directory, fs.constants.O_RDONLY);
+    fs.fsyncSync(directoryDescriptor);
+    fs.closeSync(directoryDescriptor);
+  } catch (error) {
+    if (create && (error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw recoveryError(
+        'AUTHORITY_JOURNAL_EXISTS',
+        'Authority session already has a commit transaction.',
+      );
+    }
+    throw error;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function assertJournalMatchesSession(
+  journal: AuthorityCommitJournal,
+  session: AuthoritySession,
+): void {
+  if (
+    journal.sessionId !== session.sessionId ||
+    journal.grantId !== session.grantId ||
+    journal.changeId !== session.changeId ||
+    journal.repositoryRoot !== session.repositoryRoot ||
+    journal.branch !== session.branch ||
+    journal.baseCommit !== session.baseCommit ||
+    journal.policyBlob !== session.policyBlob ||
+    journal.signer !== session.signer ||
+    JSON.stringify(journal.allowedPaths) !==
+      JSON.stringify([...journal.allowedPaths].sort()) ||
+    journal.allowedPaths.some((entry) => !session.allowedPaths.includes(entry))
+  ) {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_SESSION_MISMATCH',
+      'Authority journal does not match the pinned authority session.',
+    );
+  }
+}
+
+function isJournal(value: unknown): value is AuthorityCommitJournal {
+  if (!isRecord(value)) return false;
+  const keys = [
+    'schemaVersion',
+    'state',
+    'sessionId',
+    'grantId',
+    'changeId',
+    'repositoryRoot',
+    'branch',
+    'baseCommit',
+    'expectedTree',
+    'previousIndexTree',
+    'allowedPaths',
+    'subject',
+    'messageDigest',
+    'policyBlob',
+    'signer',
+    'commitHash',
+    'reason',
+    'createdAt',
+    'updatedAt',
+  ].sort();
+  const actualKeys = Object.keys(value).sort();
+  return (
+    actualKeys.length === keys.length &&
+    actualKeys.every((entry, index) => entry === keys[index]) &&
+    value.schemaVersion === 1 &&
+    [
+      'preparing',
+      'commit-created',
+      'ref-updated',
+      'consumed',
+      'revoked',
+    ].includes(String(value.state)) &&
+    typeof value.sessionId === 'string' &&
+    typeof value.grantId === 'string' &&
+    typeof value.changeId === 'string' &&
+    typeof value.repositoryRoot === 'string' &&
+    typeof value.branch === 'string' &&
+    typeof value.subject === 'string' &&
+    typeof value.signer === 'string' &&
+    Array.isArray(value.allowedPaths) &&
+    value.allowedPaths.every((entry) => typeof entry === 'string') &&
+    isObjectId(value.baseCommit) &&
+    isObjectId(value.expectedTree) &&
+    isObjectId(value.previousIndexTree) &&
+    isObjectId(value.policyBlob) &&
+    typeof value.messageDigest === 'string' &&
+    /^[0-9a-f]{64}$/.test(value.messageDigest) &&
+    (value.commitHash === null || isObjectId(value.commitHash)) &&
+    (value.reason === null || typeof value.reason === 'string') &&
+    isTimestamp(value.createdAt) &&
+    isTimestamp(value.updatedAt)
+  );
+}
+
+function result(
+  session: AuthoritySession,
+  journal: AuthorityCommitJournal,
+  commitHash: string,
+): AuthorityCommitResult {
+  return {
+    session,
+    grantId: journal.grantId,
+    commitHash,
+    changedPaths: [...journal.allowedPaths],
+    journalState: 'consumed',
+  };
+}
+
+function requireCommitHash(journal: AuthorityCommitJournal): string {
+  if (!journal.commitHash) {
+    throw recoveryError(
+      'AUTHORITY_JOURNAL_COMMIT_MISSING',
+      'Authority journal does not identify its commit object.',
+    );
+  }
+  return journal.commitHash;
+}
+
+function assertObjectId(value: string): string {
+  if (!isObjectId(value)) {
+    throw recoveryError(
+      'AUTHORITY_OBJECT_ID_INVALID',
+      'Authority transaction requires full Git object IDs.',
+    );
+  }
+  return value;
+}
+
+function isObjectId(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-f]{40,64}$/.test(value);
+}
+
+function exactDate(value: Date): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw recoveryError(
+      'AUTHORITY_RECOVERY_TIME_INVALID',
+      'Authority recovery requires an exact timestamp.',
+    );
+  }
+  return date;
+}
+
+function isTimestamp(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    Number.isFinite(Date.parse(value)) &&
+    new Date(value).toISOString() === value
+  );
+}
+
+function digest(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function recoveryError(code: string, message: string) {
+  return workflowError(code, message, ExitCode.staleState);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/workflow-engine/src/maintainer-report.ts
+++ b/packages/workflow-engine/src/maintainer-report.ts
@@ -1,0 +1,39 @@
+import type { CheckEvidence } from './check-runner.ts';
+import { writeImmutableReport, type WorkflowReport } from './report-store.ts';
+
+export function writeAuthorityCheckReport(
+  reportsRoot: string,
+  input: {
+    sessionId: string;
+    changeId: string;
+    grantId: string;
+    baseCommit: string;
+    policyBlob: string;
+    contractDigest: string;
+    allowedPaths: string[];
+    changedPaths: string[];
+    requiredChecks: string[];
+    checks: CheckEvidence[];
+    fingerprint: string;
+    createdAt: string;
+  },
+): string {
+  const report: WorkflowReport = {
+    schemaVersion: 1,
+    kind: 'authority-check',
+    sessionId: input.sessionId,
+    changeId: input.changeId,
+    taskId: 'authority-maintenance',
+    createdAt: input.createdAt,
+    grantId: input.grantId,
+    baseCommit: input.baseCommit,
+    policyBlob: input.policyBlob,
+    contractDigest: input.contractDigest,
+    allowedPaths: input.allowedPaths,
+    changedPaths: input.changedPaths,
+    requiredChecks: input.requiredChecks,
+    checks: input.checks,
+    fingerprint: input.fingerprint,
+  };
+  return writeImmutableReport(reportsRoot, report);
+}

--- a/packages/workflow-engine/src/maintainer-report.ts
+++ b/packages/workflow-engine/src/maintainer-report.ts
@@ -1,5 +1,11 @@
 import type { CheckEvidence } from './check-runner.ts';
-import { writeImmutableReport, type WorkflowReport } from './report-store.ts';
+import { ExitCode, workflowError } from './errors.ts';
+import type { AuthoritySession } from './maintainer-session.ts';
+import {
+  readImmutableReport,
+  writeImmutableReport,
+  type WorkflowReport,
+} from './report-store.ts';
 
 export function writeAuthorityCheckReport(
   reportsRoot: string,
@@ -36,4 +42,75 @@ export function writeAuthorityCheckReport(
     fingerprint: input.fingerprint,
   };
   return writeImmutableReport(reportsRoot, report);
+}
+
+export function readCurrentAuthorityCheckReport(
+  reportsRoot: string,
+  session: AuthoritySession,
+  changedPaths: string[],
+  fingerprint: string,
+): WorkflowReport & {
+  kind: 'authority-check';
+  checks: CheckEvidence[];
+} {
+  if (!session.latestCheckReportId) {
+    throw staleAuthorityReport('AUTHORITY_CHECK_REPORT_REQUIRED');
+  }
+  const report = readImmutableReport(
+    reportsRoot,
+    session.sessionId,
+    session.latestCheckReportId,
+  );
+  const checks = Array.isArray(report.checks)
+    ? (report.checks as unknown[])
+    : [];
+  const checksAreExact =
+    checks.length === session.requiredChecks.length &&
+    checks.every((value, index) => {
+      const expected = session.pinnedChecks[index];
+      if (!isRecord(value) || !expected) return false;
+      return (
+        value.checkId === session.requiredChecks[index] &&
+        value.outcome === 'passed' &&
+        value.exitCode === 0 &&
+        value.runner === expected.runner.runner &&
+        value.runnerDigest === expected.runner.digest &&
+        value.destructiveDatabase === expected.definition.destructiveDatabase
+      );
+    });
+  if (
+    report.kind !== 'authority-check' ||
+    report.sessionId !== session.sessionId ||
+    report.changeId !== session.changeId ||
+    report.taskId !== 'authority-maintenance' ||
+    report.grantId !== session.grantId ||
+    report.baseCommit !== session.baseCommit ||
+    report.policyBlob !== session.policyBlob ||
+    report.contractDigest !== session.contractDigest ||
+    JSON.stringify(report.allowedPaths) !==
+      JSON.stringify(session.allowedPaths) ||
+    JSON.stringify(report.changedPaths) !== JSON.stringify(changedPaths) ||
+    JSON.stringify(report.requiredChecks) !==
+      JSON.stringify(session.requiredChecks) ||
+    report.fingerprint !== fingerprint ||
+    !checksAreExact
+  ) {
+    throw staleAuthorityReport('AUTHORITY_CHECK_REPORT_STALE');
+  }
+  return report as WorkflowReport & {
+    kind: 'authority-check';
+    checks: CheckEvidence[];
+  };
+}
+
+function staleAuthorityReport(code: string) {
+  return workflowError(
+    code,
+    'A current passing authority-check report is required before commit.',
+    ExitCode.verification,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/workflow-engine/src/maintainer-session.ts
+++ b/packages/workflow-engine/src/maintainer-session.ts
@@ -1,0 +1,769 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  pinCheckRunner,
+  runCheck,
+  type CheckEvidence,
+  type PinnedCheckRunner,
+} from './check-runner.ts';
+import type { CheckDefinition } from './contracts.ts';
+import {
+  assertDisposableDatabase,
+  createCheckEnvironment,
+} from './database-policy.ts';
+import { ExitCode, WorkflowError, workflowError } from './errors.ts';
+import {
+  discoverRepository,
+  fingerprintWorkingState,
+  listChangedPaths,
+  runGit,
+} from './git.ts';
+import {
+  assertGrantPathsEligible,
+  canonicalGrantEnvelope,
+  canonicalGrantPayload,
+  validateGrantPayload,
+  type MaintainerGrantEnvelope,
+} from './maintainer-grant.ts';
+import {
+  parseMaintainerPolicy,
+  type MaintainerPolicy,
+} from './maintainer-policy.ts';
+import {
+  createInteractiveSshSigner,
+  type MaintainerSignerProvider,
+} from './maintainer-signer.ts';
+import { writeAuthorityCheckReport } from './maintainer-report.ts';
+import {
+  maintainerGrantStorePaths,
+  readReservedMaintainerGrant,
+  reserveMaintainerGrant,
+  terminallyRevokeMaintainerReservation,
+} from './maintainer-store.ts';
+import { assertChangeId, assertSessionId } from './paths.ts';
+import { createSessionId } from './session-store.ts';
+import { loadStableValidatedChangeContract } from './validated-contract-context.ts';
+
+export type AuthorityPinnedCheck = {
+  checkId: string;
+  definition: CheckDefinition;
+  runner: PinnedCheckRunner;
+};
+
+export type AuthoritySession = {
+  schemaVersion: 1;
+  sessionId: string;
+  state: 'active' | 'failed' | 'aborted';
+  grantId: string;
+  changeId: string;
+  repositoryRoot: string;
+  gitCommonDirectory: string;
+  branch: string;
+  baseCommit: string;
+  baselineTree: string;
+  policyBlob: string;
+  policyDigest: string;
+  grantDigest: string;
+  signer: string;
+  contractDigest: string;
+  contractArtifacts: Record<string, string>;
+  allowedPaths: string[];
+  requiredChecks: string[];
+  pinnedChecks: AuthorityPinnedCheck[];
+  createdAt: string;
+  latestCheckReportId?: string;
+  failedAt?: string;
+  failureReason?: string;
+  abortedAt?: string;
+  abortReason?: string;
+};
+
+export type AuthoritySessionOptions = {
+  now?: Date;
+  signer?: MaintainerSignerProvider;
+  environment?: NodeJS.ProcessEnv;
+};
+
+export function startAuthoritySession(
+  cwd: string,
+  requestedChangeId: string,
+  requestedGrantId: string,
+  options: AuthoritySessionOptions = {},
+): AuthoritySession {
+  const changeId = assertChangeId(requestedChangeId);
+  const initial = discoverRepository(cwd);
+  if (initial.statusEntries.length > 0 || !initial.branch) {
+    throw authorityError(
+      'AUTHORITY_START_DIRTY',
+      'Authority start requires a clean named branch.',
+    );
+  }
+  const sessionId = createSessionId();
+  const reservation = reserveMaintainerGrant(
+    initial.gitCommonDirectory,
+    requestedGrantId,
+    {
+      sessionId,
+      repositoryRoot: initial.repositoryRealPath,
+      now: options.now,
+    },
+  );
+  try {
+    const envelope = reservation.envelope;
+    if (
+      reservation.repositoryRoot !== initial.repositoryRealPath ||
+      envelope.payload.changeId !== changeId ||
+      envelope.payload.baseCommit !== initial.head
+    ) {
+      throw authorityError(
+        'AUTHORITY_GRANT_MISMATCH',
+        'The reserved grant does not match this repository, change, or base.',
+      );
+    }
+    const { policy, policyContent, policyBlob } = loadBasePolicy(
+      initial.repositoryRoot,
+      initial.head,
+    );
+    validateGrantPayload(envelope.payload, policy, {
+      now: exactDate(options.now ?? new Date()),
+      expectedBase: initial.head,
+      expectedPolicyBlob: policyBlob,
+    });
+    verifyEnvelopeSignature(
+      initial.repositoryRoot,
+      envelope,
+      policy,
+      options.signer,
+    );
+    assertExactAuditTag(initial.repositoryRoot, envelope, policy);
+    assertGrantPathsEligible(
+      initial.repositoryRoot,
+      envelope.payload.allowedPaths,
+      policy,
+    );
+    const { git, contract } = loadStableValidatedChangeContract(
+      initial,
+      changeId,
+    );
+    const expectedBranch = contract.config.branchTemplate.replace(
+      '{changeId}',
+      changeId,
+    );
+    if (
+      git.branch !== expectedBranch ||
+      git.head !== envelope.payload.baseCommit
+    ) {
+      throw authorityError(
+        'AUTHORITY_BRANCH_INVALID',
+        `Authority start requires branch ${expectedBranch} at the exact grant base.`,
+      );
+    }
+    const requiredChecks = requiredAuthorityChecks(
+      policy,
+      contract.guard.tasks,
+    );
+    const pinnedChecks = requiredChecks.map((checkId) => {
+      const definition = contract.checks.checks[checkId];
+      if (!definition) {
+        throw authorityError(
+          'AUTHORITY_CHECK_UNKNOWN',
+          `Authority policy references unknown check ${checkId}.`,
+        );
+      }
+      return {
+        checkId,
+        definition,
+        runner: pinCheckRunner(git.repositoryRoot, checkId, definition),
+      };
+    });
+    const createdAt = exactDate(options.now ?? new Date()).toISOString();
+    const session: AuthoritySession = {
+      schemaVersion: 1,
+      sessionId,
+      state: 'active',
+      grantId: envelope.payload.grantId,
+      changeId,
+      repositoryRoot: git.repositoryRealPath,
+      gitCommonDirectory: git.gitCommonDirectory,
+      branch: git.branch,
+      baseCommit: git.head,
+      baselineTree: git.tree,
+      policyBlob,
+      policyDigest: digest(policyContent),
+      grantDigest: digest(canonicalGrantEnvelope(envelope)),
+      signer: envelope.payload.signer,
+      contractDigest: contract.contractDigest,
+      contractArtifacts: Object.fromEntries(
+        Object.entries(contract.artifactDigests).filter(
+          ([filePath]) => !envelope.payload.allowedPaths.includes(filePath),
+        ),
+      ),
+      allowedPaths: [...envelope.payload.allowedPaths],
+      requiredChecks,
+      pinnedChecks,
+      createdAt,
+    };
+    writeAuthoritySession(session, true);
+    return session;
+  } catch (error) {
+    terminallyRevokeMaintainerReservation(
+      initial.gitCommonDirectory,
+      reservation.grantId,
+      sessionId,
+      failureReason(error),
+      options.now,
+    );
+    throw error;
+  }
+}
+
+export function checkAuthoritySession(
+  cwd: string,
+  requestedSessionId: string,
+  options: AuthoritySessionOptions = {},
+): {
+  sessionId: string;
+  grantId: string;
+  changedPaths: string[];
+  checks: CheckEvidence[];
+  reportId: string;
+  passed: true;
+} {
+  const initialSession = readAuthoritySession(cwd, requestedSessionId);
+  if (initialSession.state !== 'active') {
+    throw authorityError(
+      'AUTHORITY_SESSION_NOT_ACTIVE',
+      `Authority session ${initialSession.sessionId} is ${initialSession.state}.`,
+    );
+  }
+  try {
+    const { git, envelope, contractDigest } = inspectAuthoritySession(
+      cwd,
+      initialSession,
+      options,
+    );
+    const changedPaths = listChangedPaths(git.repositoryRoot, git.head);
+    const allowedPaths = envelope.payload.allowedPaths;
+    const unexpectedPaths = changedPaths.filter(
+      (filePath) => !allowedPaths.includes(filePath),
+    );
+    if (changedPaths.length === 0 || unexpectedPaths.length > 0) {
+      throw authorityError(
+        'AUTHORITY_SCOPE_INVALID',
+        'Authority check requires at least one change and only exact grant paths.',
+        { unexpectedPaths },
+      );
+    }
+    const database = initialSession.pinnedChecks.some(
+      ({ definition }) => definition.destructiveDatabase,
+    )
+      ? assertDisposableDatabase(options.environment ?? process.env)
+      : undefined;
+    const initialFingerprint = fingerprintWorkingState(
+      git.repositoryRoot,
+      git.head,
+      git.statusEntries,
+    );
+    const checks: CheckEvidence[] = [];
+    for (const pinned of initialSession.pinnedChecks) {
+      checks.push(
+        runCheck(
+          git.repositoryRoot,
+          pinned.checkId,
+          pinned.definition,
+          pinned.runner,
+          createCheckEnvironment(
+            options.environment ?? process.env,
+            pinned.definition.destructiveDatabase,
+          ),
+          pinned.definition.destructiveDatabase
+            ? database?.identity
+            : undefined,
+        ),
+      );
+      const current = discoverRepository(git.repositoryRoot);
+      if (
+        current.head !== git.head ||
+        fingerprintWorkingState(
+          current.repositoryRoot,
+          current.head,
+          current.statusEntries,
+        ) !== initialFingerprint
+      ) {
+        throw authorityError(
+          'AUTHORITY_CHECK_MUTATED_WORKTREE',
+          `Required check ${pinned.checkId} changed the authority checkout.`,
+        );
+      }
+    }
+    const paths = maintainerGrantStorePaths(git.gitCommonDirectory);
+    const reportId = writeAuthorityCheckReport(paths.runtime.reports, {
+      sessionId: initialSession.sessionId,
+      changeId: initialSession.changeId,
+      grantId: initialSession.grantId,
+      baseCommit: initialSession.baseCommit,
+      policyBlob: initialSession.policyBlob,
+      contractDigest,
+      allowedPaths,
+      changedPaths,
+      requiredChecks: initialSession.requiredChecks,
+      checks,
+      fingerprint: initialFingerprint,
+      createdAt: exactDate(options.now ?? new Date()).toISOString(),
+    });
+    writeAuthoritySession(
+      { ...initialSession, latestCheckReportId: reportId },
+      false,
+    );
+    return {
+      sessionId: initialSession.sessionId,
+      grantId: envelope.payload.grantId,
+      changedPaths,
+      checks,
+      reportId,
+      passed: true,
+    };
+  } catch (error) {
+    failAuthoritySession(initialSession, error, options.now);
+    throw error;
+  }
+}
+
+export function abortAuthoritySession(
+  cwd: string,
+  requestedSessionId: string,
+  reason: string,
+  now = new Date(),
+): AuthoritySession {
+  const session = readAuthoritySession(cwd, requestedSessionId);
+  if (session.state !== 'active' || !reason || reason.trim() !== reason) {
+    throw authorityError(
+      'AUTHORITY_ABORT_INVALID',
+      'Only an active authority session may be aborted with an exact reason.',
+    );
+  }
+  terminallyRevokeMaintainerReservation(
+    session.gitCommonDirectory,
+    session.grantId,
+    session.sessionId,
+    `Authority cancellation: ${reason}`,
+    now,
+  );
+  const aborted: AuthoritySession = {
+    ...session,
+    state: 'aborted',
+    abortedAt: exactDate(now).toISOString(),
+    abortReason: reason,
+  };
+  writeAuthoritySession(aborted, false);
+  return aborted;
+}
+
+export function readAuthoritySession(
+  cwd: string,
+  requestedSessionId: string,
+): AuthoritySession {
+  const git = discoverRepository(cwd);
+  const sessionId = assertSessionId(requestedSessionId);
+  const paths = maintainerGrantStorePaths(git.gitCommonDirectory);
+  const sessionPath = path.join(paths.sessions, `${sessionId}.json`);
+  const stats = fs.lstatSync(sessionPath, { throwIfNoEntry: false });
+  if (
+    !stats?.isFile() ||
+    stats.isSymbolicLink() ||
+    stats.nlink !== 1 ||
+    (stats.mode & 0o777) !== 0o600
+  ) {
+    throw authorityError(
+      'AUTHORITY_SESSION_INVALID',
+      'Authority session state is unavailable or unsafe.',
+    );
+  }
+  try {
+    const raw = fs.readFileSync(sessionPath, 'utf8');
+    const value = JSON.parse(raw) as AuthoritySession;
+    if (
+      raw !== `${JSON.stringify(value)}\n` ||
+      value.schemaVersion !== 1 ||
+      value.sessionId !== sessionId ||
+      !['active', 'failed', 'aborted'].includes(value.state) ||
+      value.gitCommonDirectory !== git.gitCommonDirectory ||
+      !Array.isArray(value.allowedPaths) ||
+      !Array.isArray(value.requiredChecks) ||
+      !Array.isArray(value.pinnedChecks)
+    ) {
+      throw new Error('invalid authority session');
+    }
+    return value;
+  } catch {
+    throw authorityError(
+      'AUTHORITY_SESSION_INVALID',
+      'Authority session state is malformed.',
+    );
+  }
+}
+
+function inspectAuthoritySession(
+  cwd: string,
+  session: AuthoritySession,
+  options: AuthoritySessionOptions,
+) {
+  const git = discoverRepository(cwd);
+  if (
+    git.repositoryRealPath !== session.repositoryRoot ||
+    git.gitCommonDirectory !== session.gitCommonDirectory ||
+    git.branch !== session.branch ||
+    git.head !== session.baseCommit
+  ) {
+    throw authorityError(
+      'AUTHORITY_BASE_DRIFT',
+      'Authority repository, branch, or base changed after start.',
+    );
+  }
+  const reservation = readReservedMaintainerGrant(
+    git.gitCommonDirectory,
+    session.grantId,
+  );
+  if (
+    reservation.sessionId !== session.sessionId ||
+    reservation.repositoryRoot !== session.repositoryRoot ||
+    digest(canonicalGrantEnvelope(reservation.envelope)) !== session.grantDigest
+  ) {
+    throw authorityError(
+      'AUTHORITY_RESERVATION_MISMATCH',
+      'Authority reservation no longer matches the pinned session.',
+    );
+  }
+  const { policy, policyContent, policyBlob } = loadBasePolicy(
+    git.repositoryRoot,
+    session.baseCommit,
+  );
+  if (
+    policyBlob !== session.policyBlob ||
+    digest(policyContent) !== session.policyDigest
+  ) {
+    throw authorityError(
+      'AUTHORITY_POLICY_DRIFT',
+      'Pinned maintainer policy changed after authority start.',
+    );
+  }
+  validateGrantPayload(reservation.envelope.payload, policy, {
+    now: exactDate(options.now ?? new Date()),
+    expectedBase: session.baseCommit,
+    expectedPolicyBlob: session.policyBlob,
+  });
+  assertGrantPathsEligible(
+    git.repositoryRoot,
+    reservation.envelope.payload.allowedPaths,
+    policy,
+  );
+  verifyEnvelopeSignature(
+    git.repositoryRoot,
+    reservation.envelope,
+    policy,
+    options.signer,
+  );
+  assertExactAuditTag(git.repositoryRoot, reservation.envelope, policy);
+  const stable = loadStableValidatedChangeContract(git, session.changeId);
+  const allowedPaths = reservation.envelope.payload.allowedPaths;
+  const expectedContractArtifacts = Object.fromEntries(
+    Object.entries(stable.contract.artifactDigests).filter(
+      ([filePath]) => !allowedPaths.includes(filePath),
+    ),
+  );
+  if (!sameRecord(session.contractArtifacts, expectedContractArtifacts)) {
+    throw authorityError(
+      'AUTHORITY_CONTRACT_DRIFT',
+      'Pinned OpenSpec authority changed after start.',
+    );
+  }
+  const expectedBranch = stable.contract.config.branchTemplate.replace(
+    '{changeId}',
+    session.changeId,
+  );
+  const expectedRequiredChecks = requiredAuthorityChecks(
+    policy,
+    stable.contract.guard.tasks,
+  );
+  const baseChecks = loadBaseCheckDefinitions(
+    git.repositoryRoot,
+    session.baseCommit,
+    expectedRequiredChecks,
+  );
+  const pinnedChecksAreExact =
+    session.pinnedChecks.length === expectedRequiredChecks.length &&
+    session.pinnedChecks.every((pinned, index) => {
+      const checkId = expectedRequiredChecks[index];
+      const definition = baseChecks[checkId];
+      if (
+        pinned.checkId !== checkId ||
+        JSON.stringify(pinned.definition) !== JSON.stringify(definition)
+      ) {
+        return false;
+      }
+      try {
+        return (
+          JSON.stringify(pinned.runner) ===
+          JSON.stringify(
+            pinCheckRunner(git.repositoryRoot, checkId, definition),
+          )
+        );
+      } catch {
+        return false;
+      }
+    });
+  if (
+    reservation.envelope.payload.changeId !== session.changeId ||
+    reservation.envelope.payload.signer !== session.signer ||
+    git.branch !== expectedBranch ||
+    git.tree !== session.baselineTree ||
+    !sameStringArray(session.allowedPaths, allowedPaths) ||
+    !sameStringArray(session.requiredChecks, expectedRequiredChecks) ||
+    !pinnedChecksAreExact
+  ) {
+    throw authorityError(
+      'AUTHORITY_SESSION_MISMATCH',
+      'Authority session state differs from its signed and base-pinned inputs.',
+    );
+  }
+  return {
+    git: stable.git,
+    envelope: reservation.envelope,
+    policy,
+    contractDigest: session.contractDigest,
+  };
+}
+
+function failAuthoritySession(
+  session: AuthoritySession,
+  error: unknown,
+  now = new Date(),
+): void {
+  terminallyRevokeMaintainerReservation(
+    session.gitCommonDirectory,
+    session.grantId,
+    session.sessionId,
+    failureReason(error),
+    now,
+  );
+  writeAuthoritySession(
+    {
+      ...session,
+      state: 'failed',
+      failedAt: exactDate(now).toISOString(),
+      failureReason: failureReason(error),
+    },
+    false,
+  );
+}
+
+function loadBasePolicy(repositoryRoot: string, baseCommit: string) {
+  try {
+    const policyContent = runGit(repositoryRoot, [
+      'show',
+      `${baseCommit}:workflow/maintainer-policy.json`,
+    ]);
+    const policy = parseMaintainerPolicy(JSON.parse(policyContent));
+    const policyBlob = runGit(repositoryRoot, [
+      'rev-parse',
+      `${baseCommit}:workflow/maintainer-policy.json`,
+    ]).trim();
+    return { policy, policyContent, policyBlob };
+  } catch {
+    throw authorityError(
+      'AUTHORITY_POLICY_INVALID',
+      'The exact base maintainer policy is unavailable or invalid.',
+    );
+  }
+}
+
+function verifyEnvelopeSignature(
+  repositoryRoot: string,
+  envelope: MaintainerGrantEnvelope,
+  policy: MaintainerPolicy,
+  signer = createInteractiveSshSigner(repositoryRoot, policy),
+): void {
+  try {
+    signer.verify(
+      canonicalGrantPayload(envelope.payload),
+      envelope.signature,
+      envelope.payload.signer,
+    );
+  } catch {
+    throw authorityError(
+      'AUTHORITY_SIGNATURE_INVALID',
+      'The maintainer grant signature is invalid.',
+    );
+  }
+}
+
+function assertExactAuditTag(
+  repositoryRoot: string,
+  envelope: MaintainerGrantEnvelope,
+  policy: MaintainerPolicy,
+): void {
+  const tagRef = `${policy.auditTagPrefix}${envelope.payload.grantId}`;
+  try {
+    const raw = runGit(repositoryRoot, ['cat-file', 'tag', tagRef]);
+    const separator = raw.indexOf('\n\n');
+    const headers = raw.slice(0, separator).split('\n');
+    const object = headers.find((line) => line.startsWith('object '))?.slice(7);
+    const type = headers.find((line) => line.startsWith('type '))?.slice(5);
+    const tag = headers.find((line) => line.startsWith('tag '))?.slice(4);
+    if (
+      separator === -1 ||
+      object !== envelope.payload.baseCommit ||
+      type !== 'commit' ||
+      tag !== tagRef.slice('refs/tags/'.length) ||
+      raw.slice(separator + 2) !== canonicalGrantEnvelope(envelope)
+    ) {
+      throw new Error('audit mismatch');
+    }
+  } catch {
+    throw authorityError(
+      'AUTHORITY_AUDIT_TAG_INVALID',
+      'The exact maintainer audit tag is missing or different.',
+    );
+  }
+}
+
+function writeAuthoritySession(
+  session: AuthoritySession,
+  create: boolean,
+): void {
+  const paths = maintainerGrantStorePaths(session.gitCommonDirectory);
+  const target = path.join(paths.sessions, `${session.sessionId}.json`);
+  const temporary = `${target}.${process.pid}.tmp`;
+  const content = `${JSON.stringify(session)}\n`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(temporary, 'wx', 0o600);
+    fs.writeFileSync(descriptor, content, 'utf8');
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    if (create) {
+      try {
+        fs.linkSync(temporary, target);
+        fs.unlinkSync(temporary);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw authorityError(
+            'AUTHORITY_SESSION_EXISTS',
+            'Authority session state already exists.',
+          );
+        }
+        throw error;
+      }
+    } else {
+      fs.renameSync(temporary, target);
+    }
+    const directory = fs.openSync(paths.sessions, fs.constants.O_RDONLY);
+    fs.fsyncSync(directory);
+    fs.closeSync(directory);
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+    fs.rmSync(temporary, { force: true });
+  }
+}
+
+function requiredAuthorityChecks(
+  policy: MaintainerPolicy,
+  tasks: Record<string, { requiredChecks: string[] }>,
+): string[] {
+  return [
+    ...new Set([
+      ...policy.requiredChecks,
+      ...Object.values(tasks).flatMap(({ requiredChecks }) => requiredChecks),
+    ]),
+  ].sort();
+}
+
+function loadBaseCheckDefinitions(
+  repositoryRoot: string,
+  baseCommit: string,
+  requiredChecks: string[],
+): Record<string, CheckDefinition> {
+  try {
+    const raw = JSON.parse(
+      runGit(repositoryRoot, ['show', `${baseCommit}:workflow/checks.json`]),
+    ) as { schemaVersion?: unknown; checks?: unknown };
+    if (
+      raw.schemaVersion !== 1 ||
+      typeof raw.checks !== 'object' ||
+      raw.checks === null ||
+      Array.isArray(raw.checks)
+    ) {
+      throw new Error('invalid base checks');
+    }
+    const checks = raw.checks as Record<string, unknown>;
+    return Object.fromEntries(
+      requiredChecks.map((checkId) => {
+        const definition = checks[checkId] as
+          Partial<CheckDefinition> | undefined;
+        if (
+          !definition ||
+          !Array.isArray(definition.command) ||
+          !definition.command.every((part) => typeof part === 'string') ||
+          typeof definition.destructiveDatabase !== 'boolean'
+        ) {
+          throw new Error(`invalid base check ${checkId}`);
+        }
+        return [
+          checkId,
+          {
+            command: [...definition.command],
+            destructiveDatabase: definition.destructiveDatabase,
+          },
+        ];
+      }),
+    );
+  } catch {
+    throw authorityError(
+      'AUTHORITY_CHECK_INVALID',
+      'Required check definitions are unavailable from the exact grant base.',
+    );
+  }
+}
+
+function sameStringArray(left: string[], right: string[]): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function sameRecord(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function exactDate(value: Date): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw authorityError(
+      'AUTHORITY_TIME_INVALID',
+      'Authority transition requires an exact timestamp.',
+    );
+  }
+  return date;
+}
+
+function digest(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function failureReason(error: unknown): string {
+  return error instanceof WorkflowError
+    ? `${error.code}: ${error.message}`
+    : 'AUTHORITY_OPERATION_FAILED';
+}
+
+function authorityError(
+  code: string,
+  message: string,
+  details?: Record<string, unknown>,
+) {
+  return workflowError(code, message, ExitCode.staleState, { details });
+}

--- a/packages/workflow-engine/src/maintainer-session.ts
+++ b/packages/workflow-engine/src/maintainer-session.ts
@@ -55,7 +55,7 @@ export type AuthorityPinnedCheck = {
 export type AuthoritySession = {
   schemaVersion: 1;
   sessionId: string;
-  state: 'active' | 'failed' | 'aborted';
+  state: 'active' | 'failed' | 'aborted' | 'committed';
   grantId: string;
   changeId: string;
   repositoryRoot: string;
@@ -78,6 +78,8 @@ export type AuthoritySession = {
   failureReason?: string;
   abortedAt?: string;
   abortReason?: string;
+  committedAt?: string;
+  commitHash?: string;
 };
 
 export type AuthoritySessionOptions = {
@@ -388,7 +390,7 @@ export function readAuthoritySession(
       raw !== `${JSON.stringify(value)}\n` ||
       value.schemaVersion !== 1 ||
       value.sessionId !== sessionId ||
-      !['active', 'failed', 'aborted'].includes(value.state) ||
+      !['active', 'failed', 'aborted', 'committed'].includes(value.state) ||
       value.gitCommonDirectory !== git.gitCommonDirectory ||
       !Array.isArray(value.allowedPaths) ||
       !Array.isArray(value.requiredChecks) ||
@@ -403,6 +405,51 @@ export function readAuthoritySession(
       'Authority session state is malformed.',
     );
   }
+}
+
+export function inspectActiveAuthoritySession(
+  cwd: string,
+  requestedSessionId: string,
+  options: AuthoritySessionOptions = {},
+) {
+  const session = readAuthoritySession(cwd, requestedSessionId);
+  if (session.state !== 'active') {
+    throw authorityError(
+      'AUTHORITY_SESSION_NOT_ACTIVE',
+      `Authority session ${session.sessionId} is ${session.state}.`,
+    );
+  }
+  return { session, ...inspectAuthoritySession(cwd, session, options) };
+}
+
+export function markAuthoritySessionCommitted(
+  cwd: string,
+  expected: AuthoritySession,
+  commitHash: string,
+  now = new Date(),
+): AuthoritySession {
+  const current = readAuthoritySession(cwd, expected.sessionId);
+  if (current.state === 'committed' && current.commitHash === commitHash) {
+    return current;
+  }
+  if (
+    current.state !== 'active' ||
+    JSON.stringify(current) !== JSON.stringify(expected) ||
+    !/^[0-9a-f]{40,64}$/.test(commitHash)
+  ) {
+    throw authorityError(
+      'AUTHORITY_SESSION_CHANGED',
+      'Authority session changed before commit finalization.',
+    );
+  }
+  const committed: AuthoritySession = {
+    ...current,
+    state: 'committed',
+    committedAt: exactDate(now).toISOString(),
+    commitHash,
+  };
+  writeAuthoritySession(committed, false);
+  return committed;
 }
 
 function inspectAuthoritySession(
@@ -536,7 +583,7 @@ function inspectAuthoritySession(
   };
 }
 
-function failAuthoritySession(
+export function failAuthoritySession(
   session: AuthoritySession,
   error: unknown,
   now = new Date(),

--- a/packages/workflow-engine/src/maintainer-signer.ts
+++ b/packages/workflow-engine/src/maintainer-signer.ts
@@ -1,0 +1,318 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createTrustedExecutionEnvironment } from './execution-environment.ts';
+import { ExitCode, workflowError } from './errors.ts';
+import { runGit } from './git.ts';
+import type { MaintainerPolicy } from './maintainer-policy.ts';
+
+export type InteractiveSignerContext = {
+  stdinIsTty: boolean;
+  stdoutIsTty: boolean;
+  stderrIsTty: boolean;
+};
+
+export type MaintainerSignerProvider = {
+  assertHumanPresent(): void;
+  identity(): string;
+  sign(payload: string): string;
+  verify(payload: string, signature: string, identity: string): void;
+};
+
+type SigningMaterial = {
+  identity: string;
+  keyPath: string;
+};
+
+export function assertInteractiveSignerContext(
+  context: InteractiveSignerContext,
+): void {
+  if (!context.stdinIsTty || !context.stdoutIsTty || !context.stderrIsTty) {
+    throw workflowError(
+      'MAINTAINER_INTERACTIVE_REQUIRED',
+      'Maintainer grant signing requires controlling input, output, and error terminals.',
+      ExitCode.unsafeEnvironment,
+      {
+        recovery:
+          'Run the grant command directly from an interactive terminal; unattended and redirected signing are not supported.',
+      },
+    );
+  }
+}
+
+export function createInteractiveSshSigner(
+  repositoryRoot: string,
+  policy: MaintainerPolicy,
+): MaintainerSignerProvider {
+  const executable = resolveSshKeygenExecutable();
+  let material: SigningMaterial | undefined;
+
+  function requireMaterial(): SigningMaterial {
+    material ??= resolveSigningMaterial(repositoryRoot, policy, executable);
+    return material;
+  }
+
+  return {
+    assertHumanPresent() {
+      assertInteractiveSignerContext({
+        stdinIsTty: process.stdin.isTTY === true,
+        stdoutIsTty: process.stdout.isTTY === true,
+        stderrIsTty: process.stderr.isTTY === true,
+      });
+      requireMaterial();
+    },
+    identity() {
+      return requireMaterial().identity;
+    },
+    sign(payload) {
+      const selected = requireMaterial();
+      const temporaryDirectory = privateTemporaryDirectory(
+        'workflow-maintainer-sign-',
+      );
+      const payloadPath = path.join(temporaryDirectory, 'payload');
+      const signaturePath = `${payloadPath}.sig`;
+      try {
+        writePrivateFile(payloadPath, payload);
+        const result = spawnSync(
+          executable,
+          [
+            '-Y',
+            'sign',
+            '-f',
+            selected.keyPath,
+            '-n',
+            policy.signatureNamespace,
+            payloadPath,
+          ],
+          {
+            shell: false,
+            stdio: ['inherit', 'ignore', 'inherit'],
+            env: signerEnvironment(executable),
+          },
+        );
+        if (result.error || result.status !== 0) {
+          throw workflowError(
+            'MAINTAINER_SIGNATURE_FAILED',
+            'The interactive SSH signer did not create a grant signature.',
+            ExitCode.verification,
+          );
+        }
+        const signature = fs.readFileSync(signaturePath, 'utf8');
+        return signature;
+      } finally {
+        fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+      }
+    },
+    verify(payload, signature, identity) {
+      const signer = policy.trustedSigners.find(
+        (candidate) => candidate.identity === identity,
+      );
+      if (!signer) {
+        throw invalidSignature();
+      }
+      verifySshSignature(
+        executable,
+        payload,
+        signature,
+        identity,
+        signer.publicKey,
+        policy.signatureNamespace,
+      );
+    },
+  };
+}
+
+function resolveSigningMaterial(
+  repositoryRoot: string,
+  policy: MaintainerPolicy,
+  executable: string,
+): SigningMaterial {
+  const configured = runGit(
+    repositoryRoot,
+    ['config', '--local', '--get', 'user.signingkey'],
+    true,
+  ).trim();
+  if (!configured) {
+    throw workflowError(
+      'MAINTAINER_SIGNING_KEY_REQUIRED',
+      'Maintainer signing requires a local Git user.signingkey file.',
+      ExitCode.unsafeEnvironment,
+      {
+        recovery:
+          'Configure an encrypted SSH private key or FIDO security-key stub with git config --local user.signingkey <absolute-or-tilde-path>.',
+      },
+    );
+  }
+
+  const expanded = configured.startsWith('~/')
+    ? path.join(os.homedir(), configured.slice(2))
+    : configured;
+  if (!path.isAbsolute(expanded)) {
+    throw unsafeSigningKey();
+  }
+  const keyStats = fs.lstatSync(expanded, { throwIfNoEntry: false });
+  if (!keyStats?.isFile() || keyStats.isSymbolicLink()) {
+    throw unsafeSigningKey();
+  }
+  const keyPath = fs.realpathSync(expanded);
+  const fingerprintResult = spawnSync(
+    executable,
+    ['-l', '-E', 'sha256', '-f', keyPath],
+    {
+      encoding: 'utf8',
+      shell: false,
+      env: signerEnvironment(executable),
+    },
+  );
+  if (fingerprintResult.error || fingerprintResult.status !== 0) {
+    throw unsafeSigningKey();
+  }
+  const fingerprint = fingerprintResult.stdout.match(
+    /SHA256:[A-Za-z0-9+/]+/,
+  )?.[0];
+  const trusted = policy.trustedSigners.find(
+    (candidate) => candidate.fingerprint === fingerprint,
+  );
+  if (!trusted) {
+    throw workflowError(
+      'MAINTAINER_SIGNER_UNTRUSTED',
+      'The configured SSH signing key is not trusted by the base maintainer policy.',
+      ExitCode.guard,
+    );
+  }
+
+  const hardwareKey = /\((?:ED25519|ECDSA)-SK\)\s*$/.test(
+    fingerprintResult.stdout.trim(),
+  );
+  if (!hardwareKey) {
+    const emptyPassphraseProbe = spawnSync(
+      executable,
+      ['-y', '-P', '', '-f', keyPath],
+      {
+        shell: false,
+        stdio: 'ignore',
+        env: signerEnvironment(executable),
+      },
+    );
+    if (emptyPassphraseProbe.status === 0) {
+      throw workflowError(
+        'MAINTAINER_UNENCRYPTED_KEY_REJECTED',
+        'An unencrypted software SSH key cannot issue maintainer grants.',
+        ExitCode.unsafeEnvironment,
+        {
+          recovery:
+            'Use a passphrase-encrypted SSH private key or a FIDO security key.',
+        },
+      );
+    }
+  }
+
+  return {
+    identity: trusted.identity,
+    keyPath,
+  };
+}
+
+function verifySshSignature(
+  executable: string,
+  payload: string,
+  signature: string,
+  identity: string,
+  publicKey: string,
+  namespace: string,
+): void {
+  const temporaryDirectory = privateTemporaryDirectory(
+    'workflow-maintainer-verify-',
+  );
+  const allowedSignersPath = path.join(temporaryDirectory, 'allowed-signers');
+  const signaturePath = path.join(temporaryDirectory, 'signature');
+  try {
+    writePrivateFile(allowedSignersPath, `${identity} ${publicKey}\n`);
+    writePrivateFile(signaturePath, signature);
+    const result = spawnSync(
+      executable,
+      [
+        '-Y',
+        'verify',
+        '-f',
+        allowedSignersPath,
+        '-I',
+        identity,
+        '-n',
+        namespace,
+        '-s',
+        signaturePath,
+      ],
+      {
+        encoding: 'utf8',
+        shell: false,
+        input: payload,
+        env: signerEnvironment(executable),
+      },
+    );
+    if (result.error || result.status !== 0) {
+      throw invalidSignature();
+    }
+  } finally {
+    fs.rmSync(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function signerEnvironment(executable: string): NodeJS.ProcessEnv {
+  const environment = createTrustedExecutionEnvironment([executable]);
+  delete environment.SSH_AUTH_SOCK;
+  delete environment.SSH_ASKPASS;
+  delete environment.SSH_ASKPASS_REQUIRE;
+  delete environment.DISPLAY;
+  return environment;
+}
+
+function resolveSshKeygenExecutable(): string {
+  if (process.platform === 'win32') {
+    throw workflowError(
+      'MAINTAINER_SIGNER_UNAVAILABLE',
+      'The interactive OpenSSH signer is unavailable on this platform.',
+      ExitCode.unsafeEnvironment,
+    );
+  }
+  for (const candidate of ['/usr/bin/ssh-keygen', '/bin/ssh-keygen']) {
+    const stats = fs.lstatSync(candidate, { throwIfNoEntry: false });
+    if (stats?.isFile() && !stats.isSymbolicLink()) {
+      return fs.realpathSync(candidate);
+    }
+  }
+  throw workflowError(
+    'MAINTAINER_SIGNER_UNAVAILABLE',
+    'A trusted system ssh-keygen executable is required.',
+    ExitCode.unsafeEnvironment,
+  );
+}
+
+function privateTemporaryDirectory(prefix: string): string {
+  const directory = fs.mkdtempSync(path.join(fs.realpathSync('/tmp'), prefix));
+  fs.chmodSync(directory, 0o700);
+  return directory;
+}
+
+function writePrivateFile(filePath: string, content: string): void {
+  fs.writeFileSync(filePath, content, { encoding: 'utf8', mode: 0o600 });
+  fs.chmodSync(filePath, 0o600);
+}
+
+function unsafeSigningKey() {
+  return workflowError(
+    'MAINTAINER_SIGNING_KEY_UNSAFE',
+    'The configured SSH signing key must be an absolute, regular, non-symlink file.',
+    ExitCode.unsafeEnvironment,
+  );
+}
+
+function invalidSignature() {
+  return workflowError(
+    'MAINTAINER_SIGNATURE_INVALID',
+    'The maintainer grant SSH signature is invalid.',
+    ExitCode.verification,
+  );
+}

--- a/packages/workflow-engine/src/maintainer-store.ts
+++ b/packages/workflow-engine/src/maintainer-store.ts
@@ -270,6 +270,93 @@ export function terminallyRevokeMaintainerReservation(
   );
 }
 
+export function consumeMaintainerReservation(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+  requestedSessionId: string,
+  requestedCommitHash: string,
+  now: Date = new Date(),
+): MaintainerGrantInspection {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const sessionId = nonEmpty(requestedSessionId, 'reservation session ID');
+  const commitHash = requestedCommitHash.trim();
+  if (!/^[0-9a-f]{40,64}$/.test(commitHash)) {
+    throw workflowError(
+      'MAINTAINER_COMMIT_INVALID',
+      'Maintainer consumption requires a full commit object ID.',
+      ExitCode.guard,
+    );
+  }
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  return withRepositoryLifecycleOperation(
+    paths.runtime,
+    (assertOwned) => {
+      assertOwned();
+      return consumeMaintainerReservationUnderLifecycleLock(
+        gitCommonDirectory,
+        grantId,
+        sessionId,
+        commitHash,
+        now,
+      );
+    },
+    { allowMaintainerGrantId: grantId },
+  );
+}
+
+export function consumeMaintainerReservationUnderLifecycleLock(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+  requestedSessionId: string,
+  requestedCommitHash: string,
+  now: Date = new Date(),
+): MaintainerGrantInspection {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const sessionId = nonEmpty(requestedSessionId, 'reservation session ID');
+  const commitHash = requestedCommitHash.trim();
+  if (!/^[0-9a-f]{40,64}$/.test(commitHash)) {
+    throw workflowError(
+      'MAINTAINER_COMMIT_INVALID',
+      'Maintainer consumption requires a full commit object ID.',
+      ExitCode.guard,
+    );
+  }
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  ensureStoreDirectories(paths);
+  const terminalPath = grantPath(paths.terminal, grantId);
+  if (fs.existsSync(terminalPath)) {
+    const terminal = readTerminal(terminalPath, grantId);
+    if (
+      terminal.state !== 'consumed' ||
+      terminal.sessionId !== sessionId ||
+      terminal.commitHash !== commitHash
+    ) {
+      throw unavailableGrant(grantId);
+    }
+    cleanupNonterminalCopies(paths, grantId, terminal.envelope);
+    return inspectTerminal(terminal);
+  }
+
+  const reservedPath = grantPath(paths.reserved, grantId);
+  const reservation = readReservation(reservedPath, grantId);
+  if (reservation.sessionId !== sessionId) {
+    throw unavailableGrant(grantId);
+  }
+  const terminal: MaintainerTerminalRecord = {
+    schemaVersion: 1,
+    state: 'consumed',
+    grantId,
+    sessionId,
+    commitHash,
+    reason: 'Signed authority commit accepted',
+    recordedAt: exactDate(now).toISOString(),
+    envelope: reservation.envelope,
+  };
+  createPrivateFileAtomic(terminalPath, serializeRecord(terminal));
+  cleanupNonterminalCopies(paths, grantId, reservation.envelope);
+  return inspectTerminal(terminal);
+}
+
 function inspectOne(
   paths: ReturnType<typeof maintainerGrantStorePaths>,
   grantId: string,

--- a/packages/workflow-engine/src/maintainer-store.ts
+++ b/packages/workflow-engine/src/maintainer-store.ts
@@ -1,0 +1,639 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ExitCode, workflowError } from './errors.ts';
+import { ensurePlainDirectory } from './filesystem-safety.ts';
+import {
+  assertMaintainerGrantId,
+  canonicalGrantEnvelope,
+  parseMaintainerGrantEnvelope,
+  type MaintainerGrantEnvelope,
+} from './maintainer-grant.ts';
+import {
+  listActiveWorkflowSessionIds,
+  runtimePaths,
+  withRepositoryLifecycleOperation,
+} from './session-store.ts';
+
+export type MaintainerReservationRecord = {
+  schemaVersion: 1;
+  state: 'reserved';
+  grantId: string;
+  sessionId: string;
+  repositoryRoot: string;
+  reservedAt: string;
+  envelope: MaintainerGrantEnvelope;
+};
+
+export type MaintainerTerminalRecord = {
+  schemaVersion: 1;
+  state: 'revoked' | 'consumed';
+  grantId: string;
+  sessionId: string | null;
+  commitHash: string | null;
+  reason: string;
+  recordedAt: string;
+  envelope: MaintainerGrantEnvelope;
+};
+
+export type MaintainerGrantInspection = {
+  grantId: string;
+  state: 'available' | 'reserved' | 'revoked' | 'consumed';
+  changeId: string;
+  baseCommit: string;
+  allowedPaths: string[];
+  issuedAt: string;
+  expiresAt: string;
+  signer: string;
+  reservationSessionId?: string;
+  terminalReason?: string;
+  commitHash?: string;
+};
+
+type ReservationRequest = {
+  sessionId: string;
+  repositoryRoot: string;
+  now?: Date;
+};
+
+export function maintainerGrantStorePaths(gitCommonDirectory: string) {
+  const runtime = runtimePaths(gitCommonDirectory, 'workflow-engine');
+  const root = path.join(runtime.root, 'maintainer-grants');
+  return {
+    runtime,
+    root,
+    available: path.join(root, 'available'),
+    reserved: path.join(root, 'reserved'),
+    terminal: path.join(root, 'terminal'),
+    journals: path.join(root, 'journals'),
+  };
+}
+
+export function storeAvailableMaintainerGrant(
+  gitCommonDirectory: string,
+  envelope: MaintainerGrantEnvelope,
+): string {
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  const grantId = assertMaintainerGrantId(envelope.payload.grantId);
+  return withRepositoryLifecycleOperation(paths.runtime, (assertOwned) => {
+    ensureStoreDirectories(paths);
+    assertOwned();
+    assertNoGrantState(paths, grantId);
+    const target = grantPath(paths.available, grantId);
+    createPrivateFileAtomic(target, canonicalGrantEnvelope(envelope));
+    return target;
+  });
+}
+
+export function reserveMaintainerGrant(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+  request: ReservationRequest,
+): MaintainerReservationRecord {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  return withRepositoryLifecycleOperation(paths.runtime, (assertOwned) => {
+    ensureStoreDirectories(paths);
+    const activeSessions = listActiveWorkflowSessionIds(paths.runtime);
+    if (activeSessions.length > 0) {
+      throw workflowError(
+        'ACTIVE_SESSION_CONFLICT',
+        'Maintainer authority requires no active ordinary workflow session.',
+        ExitCode.conflict,
+        { details: { activeSessionIds: activeSessions } },
+      );
+    }
+    assertOwned();
+    const availablePath = grantPath(paths.available, grantId);
+    const reservedPath = grantPath(paths.reserved, grantId);
+    if (
+      fs.existsSync(reservedPath) ||
+      fs.existsSync(grantPath(paths.terminal, grantId))
+    ) {
+      throw unavailableGrant(grantId);
+    }
+    const envelope = readAvailableGrant(availablePath, grantId);
+    const now = exactDate(request.now ?? new Date());
+    const record: MaintainerReservationRecord = {
+      schemaVersion: 1,
+      state: 'reserved',
+      grantId,
+      sessionId: nonEmpty(request.sessionId, 'reservation session ID'),
+      repositoryRoot: canonicalRoot(request.repositoryRoot),
+      reservedAt: now.toISOString(),
+      envelope,
+    };
+    fs.renameSync(availablePath, reservedPath);
+    fsyncDirectory(paths.available);
+    fsyncDirectory(paths.reserved);
+    replacePrivateFileAtomic(reservedPath, serializeRecord(record));
+    return record;
+  });
+}
+
+export function readReservedMaintainerGrant(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+): MaintainerReservationRecord {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  return readReservation(grantPath(paths.reserved, grantId), grantId);
+}
+
+export function inspectMaintainerGrants(
+  gitCommonDirectory: string,
+  requestedGrantId?: string,
+): MaintainerGrantInspection[] {
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  const grantId = requestedGrantId
+    ? assertMaintainerGrantId(requestedGrantId)
+    : undefined;
+  const states = existingStateDirectories(paths);
+  const grantIds = grantId
+    ? [grantId]
+    : [
+        ...new Set(states.flatMap(({ directory }) => listGrantIds(directory))),
+      ].sort();
+  const inspected = grantIds.map((id) => inspectOne(paths, id));
+  if (grantId && inspected[0] === undefined) {
+    throw grantNotFound(grantId);
+  }
+  return inspected.filter(
+    (value): value is MaintainerGrantInspection => value !== undefined,
+  );
+}
+
+export function revokeMaintainerGrant(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+  now: Date = new Date(),
+): MaintainerGrantInspection {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  return withRepositoryLifecycleOperation(
+    paths.runtime,
+    (assertOwned) => {
+      ensureStoreDirectories(paths);
+      assertOwned();
+      const terminalPath = grantPath(paths.terminal, grantId);
+      if (fs.existsSync(terminalPath)) {
+        const terminal = readTerminal(terminalPath, grantId);
+        cleanupNonterminalCopies(paths, grantId, terminal.envelope);
+        return inspectTerminal(terminal);
+      }
+
+      const availablePath = grantPath(paths.available, grantId);
+      const reservedPath = grantPath(paths.reserved, grantId);
+      const available = fs.existsSync(availablePath)
+        ? readAvailableGrant(availablePath, grantId)
+        : undefined;
+      const reservation = fs.existsSync(reservedPath)
+        ? readReservationOrInterrupted(reservedPath, grantId)
+        : undefined;
+      if (!available && !reservation) {
+        throw grantNotFound(grantId);
+      }
+      const envelope = available ?? reservation?.envelope;
+      if (
+        !envelope ||
+        (available &&
+          reservation &&
+          canonicalGrantEnvelope(available) !==
+            canonicalGrantEnvelope(reservation.envelope))
+      ) {
+        throw ambiguousGrant(grantId);
+      }
+      const terminal: MaintainerTerminalRecord = {
+        schemaVersion: 1,
+        state: 'revoked',
+        grantId,
+        sessionId: reservation?.sessionId ?? null,
+        commitHash: null,
+        reason: 'Explicit maintainer revocation',
+        recordedAt: exactDate(now).toISOString(),
+        envelope,
+      };
+      createPrivateFileAtomic(terminalPath, serializeRecord(terminal));
+      cleanupNonterminalCopies(paths, grantId, envelope);
+      return inspectTerminal(terminal);
+    },
+    { allowMaintainerGrantId: grantId },
+  );
+}
+
+function inspectOne(
+  paths: ReturnType<typeof maintainerGrantStorePaths>,
+  grantId: string,
+): MaintainerGrantInspection | undefined {
+  const existing = [
+    fs.existsSync(grantPath(paths.available, grantId)) && 'available',
+    fs.existsSync(grantPath(paths.reserved, grantId)) && 'reserved',
+    fs.existsSync(grantPath(paths.terminal, grantId)) && 'terminal',
+  ].filter(Boolean);
+  if (existing.length === 0) {
+    return undefined;
+  }
+  if (existing.length !== 1) {
+    throw ambiguousGrant(grantId);
+  }
+  if (existing[0] === 'available') {
+    return inspectEnvelope(
+      readAvailableGrant(grantPath(paths.available, grantId), grantId),
+      'available',
+    );
+  }
+  if (existing[0] === 'reserved') {
+    const reservation = readReservation(
+      grantPath(paths.reserved, grantId),
+      grantId,
+    );
+    return {
+      ...inspectEnvelope(reservation.envelope, 'reserved'),
+      reservationSessionId: reservation.sessionId,
+    };
+  }
+  return inspectTerminal(
+    readTerminal(grantPath(paths.terminal, grantId), grantId),
+  );
+}
+
+function inspectEnvelope(
+  envelope: MaintainerGrantEnvelope,
+  state: 'available' | 'reserved',
+): MaintainerGrantInspection {
+  const { payload } = envelope;
+  return {
+    grantId: payload.grantId,
+    state,
+    changeId: payload.changeId,
+    baseCommit: payload.baseCommit,
+    allowedPaths: [...payload.allowedPaths],
+    issuedAt: payload.issuedAt,
+    expiresAt: payload.expiresAt,
+    signer: payload.signer,
+  };
+}
+
+function inspectTerminal(
+  terminal: MaintainerTerminalRecord,
+): MaintainerGrantInspection {
+  return {
+    ...inspectEnvelope(terminal.envelope, 'available'),
+    state: terminal.state,
+    ...(terminal.sessionId ? { reservationSessionId: terminal.sessionId } : {}),
+    terminalReason: terminal.reason,
+    ...(terminal.commitHash ? { commitHash: terminal.commitHash } : {}),
+  };
+}
+
+function readAvailableGrant(
+  filePath: string,
+  grantId: string,
+): MaintainerGrantEnvelope {
+  const envelope = parseMaintainerGrantEnvelope(readPrivateFile(filePath));
+  if (envelope.payload.grantId !== grantId) {
+    throw ambiguousGrant(grantId);
+  }
+  return envelope;
+}
+
+function readReservation(
+  filePath: string,
+  grantId: string,
+): MaintainerReservationRecord {
+  const value = parseRecord(readPrivateFile(filePath));
+  if (
+    !hasExactKeys(value, [
+      'schemaVersion',
+      'state',
+      'grantId',
+      'sessionId',
+      'repositoryRoot',
+      'reservedAt',
+      'envelope',
+    ]) ||
+    value.schemaVersion !== 1 ||
+    value.state !== 'reserved' ||
+    value.grantId !== grantId ||
+    typeof value.sessionId !== 'string' ||
+    typeof value.repositoryRoot !== 'string' ||
+    typeof value.reservedAt !== 'string'
+  ) {
+    throw ambiguousGrant(grantId);
+  }
+  const envelope = parseMaintainerGrantEnvelope(
+    `${JSON.stringify(value.envelope)}\n`,
+  );
+  if (
+    envelope.payload.grantId !== grantId ||
+    !path.isAbsolute(value.repositoryRoot) ||
+    !isExactTimestamp(value.reservedAt)
+  ) {
+    throw ambiguousGrant(grantId);
+  }
+  return { ...value, envelope } as MaintainerReservationRecord;
+}
+
+function readReservationOrInterrupted(
+  filePath: string,
+  grantId: string,
+): { envelope: MaintainerGrantEnvelope; sessionId?: string } {
+  try {
+    return readReservation(filePath, grantId);
+  } catch {
+    return { envelope: readAvailableGrant(filePath, grantId) };
+  }
+}
+
+function readTerminal(
+  filePath: string,
+  grantId: string,
+): MaintainerTerminalRecord {
+  const value = parseRecord(readPrivateFile(filePath));
+  if (
+    !hasExactKeys(value, [
+      'schemaVersion',
+      'state',
+      'grantId',
+      'sessionId',
+      'commitHash',
+      'reason',
+      'recordedAt',
+      'envelope',
+    ]) ||
+    value.schemaVersion !== 1 ||
+    !['revoked', 'consumed'].includes(String(value.state)) ||
+    value.grantId !== grantId ||
+    (value.sessionId !== null && typeof value.sessionId !== 'string') ||
+    (value.commitHash !== null && typeof value.commitHash !== 'string') ||
+    typeof value.reason !== 'string' ||
+    typeof value.recordedAt !== 'string' ||
+    !isExactTimestamp(value.recordedAt)
+  ) {
+    throw ambiguousGrant(grantId);
+  }
+  const envelope = parseMaintainerGrantEnvelope(
+    `${JSON.stringify(value.envelope)}\n`,
+  );
+  if (envelope.payload.grantId !== grantId) {
+    throw ambiguousGrant(grantId);
+  }
+  return { ...value, envelope } as MaintainerTerminalRecord;
+}
+
+function cleanupNonterminalCopies(
+  paths: ReturnType<typeof maintainerGrantStorePaths>,
+  grantId: string,
+  expected: MaintainerGrantEnvelope,
+): void {
+  for (const directory of [paths.available, paths.reserved]) {
+    const target = grantPath(directory, grantId);
+    if (!fs.existsSync(target)) {
+      continue;
+    }
+    const observed =
+      directory === paths.available
+        ? readAvailableGrant(target, grantId)
+        : readReservationOrInterrupted(target, grantId).envelope;
+    if (canonicalGrantEnvelope(observed) !== canonicalGrantEnvelope(expected)) {
+      throw ambiguousGrant(grantId);
+    }
+    fs.unlinkSync(target);
+    fsyncDirectory(directory);
+  }
+}
+
+function ensureStoreDirectories(
+  paths: ReturnType<typeof maintainerGrantStorePaths>,
+): void {
+  for (const directory of [
+    paths.root,
+    paths.available,
+    paths.reserved,
+    paths.terminal,
+    paths.journals,
+  ]) {
+    const existed = fs.existsSync(directory);
+    ensurePlainDirectory(directory);
+    fs.chmodSync(directory, 0o700);
+    if ((fs.statSync(directory).mode & 0o777) !== 0o700) {
+      throw unsafeStore();
+    }
+    if (!existed) {
+      fsyncDirectory(path.dirname(directory));
+    }
+  }
+}
+
+function existingStateDirectories(
+  paths: ReturnType<typeof maintainerGrantStorePaths>,
+): Array<{ directory: string }> {
+  const directories = [paths.available, paths.reserved, paths.terminal];
+  return directories.flatMap((directory) => {
+    const stats = fs.lstatSync(directory, { throwIfNoEntry: false });
+    if (!stats) {
+      return [];
+    }
+    if (
+      !stats.isDirectory() ||
+      stats.isSymbolicLink() ||
+      fs.realpathSync(directory) !== path.resolve(directory) ||
+      (stats.mode & 0o777) !== 0o700
+    ) {
+      throw unsafeStore();
+    }
+    return [{ directory }];
+  });
+}
+
+function assertNoGrantState(
+  paths: ReturnType<typeof maintainerGrantStorePaths>,
+  grantId: string,
+): void {
+  if (
+    [paths.available, paths.reserved, paths.terminal].some((directory) =>
+      fs.existsSync(grantPath(directory, grantId)),
+    )
+  ) {
+    throw unavailableGrant(grantId);
+  }
+}
+
+function listGrantIds(directory: string): string[] {
+  return fs.readdirSync(directory).map((entry) => {
+    if (!entry.endsWith('.json')) {
+      throw unsafeStore();
+    }
+    return assertMaintainerGrantId(entry.slice(0, -'.json'.length));
+  });
+}
+
+function grantPath(directory: string, grantId: string): string {
+  return path.join(directory, `${assertMaintainerGrantId(grantId)}.json`);
+}
+
+function createPrivateFileAtomic(filePath: string, content: string): void {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(temporaryPath, 'wx', 0o600);
+    fs.writeFileSync(descriptor, content, 'utf8');
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.linkSync(temporaryPath, filePath);
+    fs.unlinkSync(temporaryPath);
+    fsyncDirectory(path.dirname(filePath));
+  } catch (error) {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+    fs.rmSync(temporaryPath, { force: true });
+    if (isNodeError(error) && error.code === 'EEXIST') {
+      throw unavailableGrant(path.basename(filePath, '.json'));
+    }
+    throw error;
+  }
+}
+
+function replacePrivateFileAtomic(filePath: string, content: string): void {
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  let descriptor: number | undefined;
+  try {
+    descriptor = fs.openSync(temporaryPath, 'wx', 0o600);
+    fs.writeFileSync(descriptor, content, 'utf8');
+    fs.fsyncSync(descriptor);
+    fs.closeSync(descriptor);
+    descriptor = undefined;
+    fs.renameSync(temporaryPath, filePath);
+    fsyncDirectory(path.dirname(filePath));
+  } finally {
+    if (descriptor !== undefined) {
+      fs.closeSync(descriptor);
+    }
+    fs.rmSync(temporaryPath, { force: true });
+  }
+}
+
+function readPrivateFile(filePath: string): string {
+  const stats = fs.lstatSync(filePath, { throwIfNoEntry: false });
+  if (
+    !stats?.isFile() ||
+    stats.isSymbolicLink() ||
+    stats.nlink !== 1 ||
+    (stats.mode & 0o777) !== 0o600
+  ) {
+    throw unsafeStore();
+  }
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function fsyncDirectory(directory: string): void {
+  const descriptor = fs.openSync(directory, fs.constants.O_RDONLY);
+  try {
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function serializeRecord(value: unknown): string {
+  return `${JSON.stringify(value)}\n`;
+}
+
+function parseRecord(raw: string): Record<string, unknown> {
+  try {
+    const value = JSON.parse(raw) as unknown;
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      Array.isArray(value) ||
+      raw !== `${JSON.stringify(value)}\n`
+    ) {
+      throw new Error('not canonical');
+    }
+    return value as Record<string, unknown>;
+  } catch {
+    throw unsafeStore();
+  }
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: string[]) {
+  const actual = Object.keys(value).sort();
+  const sorted = [...expected].sort();
+  return (
+    actual.length === sorted.length &&
+    actual.every((entry, index) => entry === sorted[index])
+  );
+}
+
+function exactDate(value: Date): Date {
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) {
+    throw workflowError(
+      'MAINTAINER_GRANT_TIME_INVALID',
+      'Maintainer grant state requires an exact timestamp.',
+      ExitCode.guard,
+    );
+  }
+  return date;
+}
+
+function isExactTimestamp(value: string): boolean {
+  const time = Date.parse(value);
+  return Number.isFinite(time) && new Date(time).toISOString() === value;
+}
+
+function canonicalRoot(value: string): string {
+  if (!path.isAbsolute(value) || fs.realpathSync(value) !== value) {
+    throw unsafeStore();
+  }
+  return value;
+}
+
+function nonEmpty(value: string, label: string): string {
+  if (!value || value.trim() !== value) {
+    throw workflowError(
+      'MAINTAINER_RESERVATION_INVALID',
+      `Maintainer ${label} is invalid.`,
+      ExitCode.guard,
+    );
+  }
+  return value;
+}
+
+function unavailableGrant(grantId: string) {
+  return workflowError(
+    'MAINTAINER_GRANT_UNAVAILABLE',
+    `Maintainer grant ${grantId} is not available for this transition.`,
+    ExitCode.conflict,
+  );
+}
+
+function grantNotFound(grantId: string) {
+  return workflowError(
+    'MAINTAINER_GRANT_NOT_FOUND',
+    `Maintainer grant ${grantId} does not exist in local state.`,
+    ExitCode.guard,
+  );
+}
+
+function ambiguousGrant(grantId: string) {
+  return workflowError(
+    'MAINTAINER_GRANT_STATE_AMBIGUOUS',
+    `Maintainer grant ${grantId} has ambiguous or malformed local state.`,
+    ExitCode.staleState,
+  );
+}
+
+function unsafeStore() {
+  return workflowError(
+    'MAINTAINER_GRANT_STORE_UNSAFE',
+    'Maintainer grant storage is malformed or unsafe.',
+    ExitCode.staleState,
+  );
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}

--- a/packages/workflow-engine/src/maintainer-store.ts
+++ b/packages/workflow-engine/src/maintainer-store.ts
@@ -66,6 +66,7 @@ export function maintainerGrantStorePaths(gitCommonDirectory: string) {
     reserved: path.join(root, 'reserved'),
     terminal: path.join(root, 'terminal'),
     journals: path.join(root, 'journals'),
+    sessions: path.join(root, 'sessions'),
   };
 }
 
@@ -215,6 +216,54 @@ export function revokeMaintainerGrant(
       };
       createPrivateFileAtomic(terminalPath, serializeRecord(terminal));
       cleanupNonterminalCopies(paths, grantId, envelope);
+      return inspectTerminal(terminal);
+    },
+    { allowMaintainerGrantId: grantId },
+  );
+}
+
+export function terminallyRevokeMaintainerReservation(
+  gitCommonDirectory: string,
+  requestedGrantId: string,
+  requestedSessionId: string,
+  reason: string,
+  now: Date = new Date(),
+): MaintainerGrantInspection {
+  const grantId = assertMaintainerGrantId(requestedGrantId);
+  const sessionId = nonEmpty(requestedSessionId, 'reservation session ID');
+  const terminalReason = nonEmpty(reason, 'terminal reason');
+  const paths = maintainerGrantStorePaths(gitCommonDirectory);
+  return withRepositoryLifecycleOperation(
+    paths.runtime,
+    (assertOwned) => {
+      ensureStoreDirectories(paths);
+      assertOwned();
+      const terminalPath = grantPath(paths.terminal, grantId);
+      if (fs.existsSync(terminalPath)) {
+        const terminal = readTerminal(terminalPath, grantId);
+        if (terminal.sessionId !== sessionId) {
+          throw unavailableGrant(grantId);
+        }
+        cleanupNonterminalCopies(paths, grantId, terminal.envelope);
+        return inspectTerminal(terminal);
+      }
+      const reservedPath = grantPath(paths.reserved, grantId);
+      const reservation = readReservation(reservedPath, grantId);
+      if (reservation.sessionId !== sessionId) {
+        throw unavailableGrant(grantId);
+      }
+      const terminal: MaintainerTerminalRecord = {
+        schemaVersion: 1,
+        state: 'revoked',
+        grantId,
+        sessionId,
+        commitHash: null,
+        reason: terminalReason,
+        recordedAt: exactDate(now).toISOString(),
+        envelope: reservation.envelope,
+      };
+      createPrivateFileAtomic(terminalPath, serializeRecord(terminal));
+      cleanupNonterminalCopies(paths, grantId, reservation.envelope);
       return inspectTerminal(terminal);
     },
     { allowMaintainerGrantId: grantId },
@@ -412,6 +461,7 @@ function ensureStoreDirectories(
     paths.reserved,
     paths.terminal,
     paths.journals,
+    paths.sessions,
   ]) {
     const existed = fs.existsSync(directory);
     ensurePlainDirectory(directory);

--- a/packages/workflow-engine/src/managed-trailers.ts
+++ b/packages/workflow-engine/src/managed-trailers.ts
@@ -16,13 +16,25 @@ export type ArchiveManagedTrailers = {
   transition: 'archive';
 };
 
-export type ManagedTrailers =
-  TaskManagedTrailers | PlanManagedTrailers | ArchiveManagedTrailers;
+export type AuthorityManagedTrailers = {
+  kind: 'authority';
+  changeId: string;
+  transition: 'authority-maintenance';
+  grantId: string;
+};
 
-const RESERVED_TRAILER_LINE = /^[\t ]*(?:change|task|transition)[\t ]*:/i;
+export type ManagedTrailers =
+  | TaskManagedTrailers
+  | PlanManagedTrailers
+  | ArchiveManagedTrailers
+  | AuthorityManagedTrailers;
+
+const RESERVED_TRAILER_LINE = /^[\t ]*(?:change|task|transition|grant)[\t ]*:/i;
 const CHANGE_TRAILER = /^Change: ([a-z0-9]+(?:-[a-z0-9]+)*)$/;
 const TASK_TRAILER = /^Task: (\d+(?:\.\d+)+)$/;
-const TRANSITION_TRAILER = /^Transition: (plan|archive)$/;
+const TRANSITION_TRAILER = /^Transition: (plan|archive|authority-maintenance)$/;
+const GRANT_TRAILER =
+  /^Grant: ([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/;
 
 export class ManagedTrailerSyntaxError extends Error {
   constructor() {
@@ -54,25 +66,41 @@ export function parseManagedTrailers(
 
   const normalized = message.endsWith('\n') ? message.slice(0, -1) : message;
   const lines = normalized.split('\n');
-  const change = CHANGE_TRAILER.exec(lines.at(-2) ?? '');
-  const task = TASK_TRAILER.exec(lines.at(-1) ?? '');
-  const transition = TRANSITION_TRAILER.exec(lines.at(-1) ?? '');
+  const authority =
+    CHANGE_TRAILER.exec(lines.at(-3) ?? '') &&
+    TRANSITION_TRAILER.exec(lines.at(-2) ?? '')?.[1] ===
+      'authority-maintenance' &&
+    GRANT_TRAILER.exec(lines.at(-1) ?? '');
+  const trailerStart = authority ? -3 : -2;
+  const change = CHANGE_TRAILER.exec(lines.at(trailerStart) ?? '');
+  const task = authority ? null : TASK_TRAILER.exec(lines.at(-1) ?? '');
+  const transition = authority
+    ? TRANSITION_TRAILER.exec(lines.at(-2) ?? '')
+    : TRANSITION_TRAILER.exec(lines.at(-1) ?? '');
   const earlierReservedLine = lines
-    .slice(0, -2)
+    .slice(0, trailerStart)
     .some((line) => RESERVED_TRAILER_LINE.test(line));
 
   if (
     normalized.endsWith('\n') ||
-    lines.at(-3) !== '' ||
+    lines.at(trailerStart - 1) !== '' ||
     !change ||
     earlierReservedLine ||
-    (task === null) === (transition === null)
+    (!authority && (task === null) === (transition === null))
   ) {
     throw new ManagedTrailerSyntaxError();
   }
 
   if (task) {
     return { kind: 'task', changeId: change[1], taskId: task[1] };
+  }
+  if (authority && transition?.[1] === 'authority-maintenance') {
+    return {
+      kind: 'authority',
+      changeId: change[1],
+      transition: 'authority-maintenance',
+      grantId: authority[1],
+    };
   }
   if (transition?.[1] === 'plan') {
     return { kind: 'plan', changeId: change[1], transition: 'plan' };

--- a/packages/workflow-engine/src/paths.ts
+++ b/packages/workflow-engine/src/paths.ts
@@ -115,6 +115,14 @@ export function normalizeChangedPath(value: string): string {
   return value;
 }
 
+export function normalizeExactRepositoryPath(value: string): string {
+  const normalized = normalizeChangedPath(value);
+  if (UNSUPPORTED_GLOB_PATTERN.test(normalized)) {
+    throw invalidRepositoryPath(value);
+  }
+  return normalized;
+}
+
 function containsControlCharacter(value: string): boolean {
   return [...value].some((character) => {
     const codePoint = character.codePointAt(0) ?? 0;

--- a/packages/workflow-engine/src/planning-lock.ts
+++ b/packages/workflow-engine/src/planning-lock.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { ExitCode, workflowError } from './errors.ts';
 import { ensurePlainDirectory } from './filesystem-safety.ts';
 import {
-  readSessionFile,
+  listActiveWorkflowSessionIds,
   type runtimePaths,
   withRepositoryLifecycleOperation,
 } from './session-store.ts';
@@ -119,24 +119,7 @@ function withChangeTransitionLock<T>(
 }
 
 function assertNoActiveSessions(runtime: RuntimePaths): void {
-  const stats = fs.lstatSync(runtime.sessions, { throwIfNoEntry: false });
-  if (!stats) {
-    return;
-  }
-  if (!stats.isDirectory() || stats.isSymbolicLink()) {
-    throw workflowError(
-      'SESSION_DIRECTORY_UNSAFE',
-      'Workflow session directory is unsafe.',
-      ExitCode.staleState,
-    );
-  }
-  const active = fs
-    .readdirSync(runtime.sessions)
-    .filter((entry) => entry.endsWith('.json'))
-    .map((entry) => readSessionFile(path.join(runtime.sessions, entry)))
-    .filter((session) => session.state === 'active')
-    .map((session) => session.sessionId)
-    .sort();
+  const active = listActiveWorkflowSessionIds(runtime);
   if (active.length > 0) {
     throw workflowError(
       'ACTIVE_SESSION_CONFLICT',

--- a/packages/workflow-engine/src/report-store.ts
+++ b/packages/workflow-engine/src/report-store.ts
@@ -7,7 +7,7 @@ import { assertSessionId } from './paths.ts';
 
 export type WorkflowReport = {
   schemaVersion: 1;
-  kind: 'check' | 'completion' | 'finish' | 'commit';
+  kind: 'check' | 'completion' | 'finish' | 'commit' | 'authority-check';
   sessionId: string;
   changeId: string;
   taskId: string;
@@ -103,7 +103,9 @@ export function readImmutableReport(
   if (
     !isRecord(value) ||
     value.schemaVersion !== 1 ||
-    !['check', 'completion', 'finish', 'commit'].includes(String(value.kind)) ||
+    !['check', 'completion', 'finish', 'commit', 'authority-check'].includes(
+      String(value.kind),
+    ) ||
     value.sessionId !== sessionId ||
     typeof value.changeId !== 'string' ||
     typeof value.taskId !== 'string' ||

--- a/packages/workflow-engine/src/session-store.ts
+++ b/packages/workflow-engine/src/session-store.ts
@@ -5,6 +5,9 @@ import path from 'node:path';
 import { ExitCode, workflowError } from './errors.ts';
 import { ensurePlainDirectory } from './filesystem-safety.ts';
 
+const MAINTAINER_GRANT_STATE_FILE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.json$/;
+
 export type WorkflowSession = {
   schemaVersion: 1;
   sessionId: string;
@@ -89,6 +92,7 @@ export function withSessionOperation<T>(
 export function withRepositoryLifecycleOperation<T>(
   runtime: ReturnType<typeof runtimePaths>,
   operation: (assertOwned: () => void) => T,
+  options: { allowMaintainerGrantId?: string } = {},
 ): T {
   ensurePlainDirectory(runtime.operations);
   const lockPath = path.join(runtime.operations, 'repository-lifecycle.lock');
@@ -166,6 +170,10 @@ export function withRepositoryLifecycleOperation<T>(
 
   let result: T;
   try {
+    assertMaintainerReservationCompatibility(
+      runtime,
+      options.allowMaintainerGrantId,
+    );
     result = operation(assertOwned);
   } catch (error) {
     release();
@@ -173,6 +181,81 @@ export function withRepositoryLifecycleOperation<T>(
   }
   release();
   return result;
+}
+
+export function listActiveWorkflowSessionIds(
+  runtime: ReturnType<typeof runtimePaths>,
+): string[] {
+  const stats = fs.lstatSync(runtime.sessions, { throwIfNoEntry: false });
+  if (!stats) {
+    return [];
+  }
+  if (!stats.isDirectory() || stats.isSymbolicLink()) {
+    throw workflowError(
+      'SESSION_DIRECTORY_UNSAFE',
+      'Workflow session directory is unsafe.',
+      ExitCode.staleState,
+    );
+  }
+  return fs
+    .readdirSync(runtime.sessions)
+    .filter((entry) => entry.endsWith('.json'))
+    .map((entry) => readSessionFile(path.join(runtime.sessions, entry)))
+    .filter((session) => session.state === 'active')
+    .map((session) => session.sessionId)
+    .sort();
+}
+
+function assertMaintainerReservationCompatibility(
+  runtime: ReturnType<typeof runtimePaths>,
+  allowedGrantId: string | undefined,
+): void {
+  const reservedDirectory = path.join(
+    runtime.root,
+    'maintainer-grants',
+    'reserved',
+  );
+  const stats = fs.lstatSync(reservedDirectory, { throwIfNoEntry: false });
+  if (!stats) {
+    return;
+  }
+  if (
+    !stats.isDirectory() ||
+    stats.isSymbolicLink() ||
+    fs.realpathSync(reservedDirectory) !== path.resolve(reservedDirectory) ||
+    (stats.mode & 0o777) !== 0o700
+  ) {
+    throw workflowError(
+      'MAINTAINER_GRANT_STORE_UNSAFE',
+      'Maintainer grant reservation storage is unsafe.',
+      ExitCode.staleState,
+    );
+  }
+  const entries = fs.readdirSync(reservedDirectory);
+  if (entries.some((entry) => !MAINTAINER_GRANT_STATE_FILE.test(entry))) {
+    throw workflowError(
+      'MAINTAINER_GRANT_STORE_UNSAFE',
+      'Maintainer grant reservation storage contains an invalid entry.',
+      ExitCode.staleState,
+    );
+  }
+  const reservations = entries
+    .map((entry) => entry.slice(0, -'.json'.length))
+    .sort();
+  if (
+    reservations.length === 0 ||
+    (allowedGrantId !== undefined &&
+      reservations.length === 1 &&
+      reservations[0] === allowedGrantId)
+  ) {
+    return;
+  }
+  throw workflowError(
+    'ACTIVE_AUTHORITY_CONFLICT',
+    'A maintainer authority reservation already owns the repository lifecycle.',
+    ExitCode.conflict,
+    { details: { grantIds: reservations } },
+  );
 }
 
 function invalidRepositoryLifecycleLock(message: string) {

--- a/packages/workflow-engine/test/ci.integration.test.ts
+++ b/packages/workflow-engine/test/ci.integration.test.ts
@@ -660,9 +660,34 @@ test('workflow assurance CI is read-only and policy paths have owners', () => {
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /runs-on: ubuntu-24\.04/);
   assert.match(workflow, /timeout-minutes: 30/);
-  assert.match(workflow, /pnpm install --frozen-lockfile --ignore-scripts/);
-  assert.match(workflow, /pnpm workflow ci/);
-  assert.doesNotMatch(workflow, /pull_request_target|secrets\./);
+  assert.match(workflow, /on:\n {2}pull_request_target:/);
+  assert.match(
+    workflow,
+    /ref: \$\{\{ github\.event\.pull_request\.base\.sha \}\}\n {10}path: trusted-base/,
+  );
+  assert.match(
+    workflow,
+    /repository: \$\{\{ github\.event\.pull_request\.head\.repo\.full_name \}\}/,
+  );
+  assert.match(workflow, /path: candidate/);
+  assert.match(workflow, /fetch-tags: true/);
+  assert.match(
+    workflow,
+    /for-each-ref --format='delete %\(refname\)' refs\/tags\/workflow-grant\//,
+  );
+  assert.match(
+    workflow,
+    /refs\/tags\/workflow-grant\/\*:refs\/tags\/workflow-grant\/\*/,
+  );
+  assert.equal(
+    workflow.match(/pnpm install --frozen-lockfile --ignore-scripts/g)?.length,
+    2,
+  );
+  assert.match(
+    workflow,
+    /\.\.\/trusted-base\/packages\/workflow-engine\/src\/cli\.ts ci/,
+  );
+  assert.doesNotMatch(workflow, /secrets\.|pnpm workflow ci/);
   const actionRefs = [...workflow.matchAll(/uses: [^@\s]+@([^\s]+)/g)].map(
     (match) => match[1],
   );

--- a/packages/workflow-engine/test/contracts.test.ts
+++ b/packages/workflow-engine/test/contracts.test.ts
@@ -16,6 +16,7 @@ import {
   normalizeChangedPath,
   normalizePolicyPath,
 } from '../src/paths.ts';
+import { workflowContractArtifactPaths } from '../src/contract-artifacts.ts';
 import { parseTasks } from '../src/contracts.ts';
 import './git-security.test.ts';
 import './openspec-adapter.integration.test.ts';
@@ -23,6 +24,21 @@ import './openspec-doctor.integration.test.ts';
 import './openspec-schema-contract.integration.test.ts';
 import './planning-transition.contract.test.ts';
 import './codex-planning-assets.integration.test.ts';
+
+test('maintainer policy is a pinned workflow contract artifact', () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+  const artifacts = workflowContractArtifactPaths(repositoryRoot).map(
+    (artifact) => path.relative(repositoryRoot, artifact),
+  );
+
+  assert.ok(artifacts.includes('workflow/maintainer-policy.json'));
+  assert.ok(
+    artifacts.includes('workflow/schemas/maintainer-policy.schema.json'),
+  );
+  assert.ok(
+    artifacts.includes('workflow/schemas/maintainer-grant.schema.json'),
+  );
+});
 
 test('runner security suite is portable to the package working directory', () => {
   execFileSync(

--- a/packages/workflow-engine/test/contracts.test.ts
+++ b/packages/workflow-engine/test/contracts.test.ts
@@ -232,6 +232,14 @@ test('agent guide documents the complete public workflow surface and source-size
     'pnpm workflow issue close',
     'pnpm workflow issue render',
     'pnpm workflow issue validate',
+    'pnpm workflow maintainer grant',
+    'pnpm workflow maintainer inspect',
+    'pnpm workflow maintainer revoke',
+    'pnpm workflow authority-start',
+    'pnpm workflow authority-check',
+    'pnpm workflow authority-commit',
+    'pnpm workflow authority-recover',
+    'pnpm workflow authority-abort',
     'pnpm workflow documents validate',
     'pnpm workflow document-refresh propose',
     'pnpm workflow document-refresh show',
@@ -258,6 +266,42 @@ test('agent guide documents the complete public workflow surface and source-size
     /Do not change, split, or refactor source\s+solely because it exceeds 500 lines\./,
   );
   assert.doesNotMatch(agents, /keep files under 500 LOC/i);
+});
+
+test('break-glass maintainer operator contract is complete and bootstrap-only', () => {
+  const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+  const workflow = fs.readFileSync(
+    path.join(repositoryRoot, 'docs/WORKFLOW.md'),
+    'utf8',
+  );
+  const roadmap = fs.readFileSync(
+    path.join(repositoryRoot, 'docs/ROADMAP.md'),
+    'utf8',
+  );
+
+  for (const command of [
+    'pnpm workflow maintainer grant',
+    'pnpm workflow maintainer inspect',
+    'pnpm workflow maintainer revoke',
+    'pnpm workflow authority-start',
+    'pnpm workflow authority-check',
+    'pnpm workflow authority-commit',
+    'pnpm workflow authority-recover',
+    'pnpm workflow authority-abort',
+  ]) {
+    assert.match(workflow, new RegExp(command.replaceAll(' ', '\\s+')));
+  }
+
+  assert.match(workflow, /controlling interactive terminal/i);
+  assert.match(workflow, /git config --local gpg\.format ssh/);
+  assert.match(workflow, /git config --local user\.signingkey/);
+  assert.match(workflow, /workflow-grant\/\*\*/);
+  assert.match(workflow, /protected environment/i);
+  assert.match(workflow, /one-way/i);
+  assert.match(workflow, /repository-admin, out-of-band/i);
+  assert.match(roadmap, /bootstrap-only/i);
+  assert.match(roadmap, /workflow-grant\/\*\*/);
+  assert.match(roadmap, /protected environment/i);
 });
 
 test('documentation entry point is a project overview and archive policy remains immutable', () => {

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -17,6 +17,12 @@ import {
   type MaintainerSignerProvider,
 } from '../src/maintainer-signer.ts';
 import {
+  inspectMaintainerGrants,
+  maintainerGrantStorePaths,
+  reserveMaintainerGrant,
+  revokeMaintainerGrant,
+} from '../src/maintainer-store.ts';
+import {
   loadMaintainerPolicy,
   parseMaintainerPolicy,
   type MaintainerPolicy,
@@ -27,6 +33,11 @@ import {
   isWorkflowError,
   sourceRepositoryRoot,
 } from './fixture.ts';
+import { abortSession, startSession } from '../src/session.ts';
+import {
+  runtimePaths,
+  withRepositoryLifecycleOperation,
+} from '../src/session-store.ts';
 
 const POLICY: MaintainerPolicy = {
   schemaVersion: 1,
@@ -431,6 +442,191 @@ test('failed signature verification leaves no token or audit tag', () => {
   }
 });
 
+test('common-dir reservation is exclusive across worktrees and revocation is idempotent', () => {
+  const repository = createFixtureRepository();
+  const grantId = '44444444-4444-4444-8444-444444444444';
+  let linkedWorktree: string | undefined;
+  try {
+    installFixtureMaintainerPolicy(repository);
+    issueMaintainerGrant(
+      repository,
+      {
+        changeId: 'demo-change',
+        paths: ['workflow/checks.json'],
+        reason: 'Repair exact workflow authority',
+      },
+      {
+        now: new Date('2026-07-16T12:00:00.000Z'),
+        grantId,
+        signer: fixtureSigner(),
+      },
+    );
+    const commonDirectory = fs.realpathSync(path.join(repository, '.git'));
+    assert.deepEqual(inspectMaintainerGrants(commonDirectory, grantId), [
+      {
+        grantId,
+        state: 'available',
+        changeId: 'demo-change',
+        baseCommit: git(repository, ['rev-parse', 'HEAD']).trim(),
+        allowedPaths: ['workflow/checks.json'],
+        issuedAt: '2026-07-16T12:00:00.000Z',
+        expiresAt: '2026-07-16T12:30:00.000Z',
+        signer: 'fixture-maintainer',
+      },
+    ]);
+
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    const ordinary = startSession(repository, 'demo-change', '1.1');
+    assert.throws(
+      () =>
+        reserveMaintainerGrant(commonDirectory, grantId, {
+          sessionId: 'authority-conflict',
+          repositoryRoot: fs.realpathSync(repository),
+        }),
+      (error) => isWorkflowError(error, 'ACTIVE_SESSION_CONFLICT'),
+    );
+    abortSession(repository, ordinary.sessionId, 'Fixture conflict complete');
+
+    linkedWorktree = fs.mkdtempSync(
+      path.join(path.dirname(repository), 'workflow-linked-'),
+    );
+    fs.rmdirSync(linkedWorktree);
+    git(repository, [
+      'worktree',
+      'add',
+      '-b',
+      'work/linked-authority',
+      linkedWorktree,
+      'HEAD',
+    ]);
+    const linkedCommon = fs.realpathSync(
+      git(linkedWorktree, ['rev-parse', '--git-common-dir']).trim(),
+    );
+    assert.equal(linkedCommon, commonDirectory);
+
+    const reservation = reserveMaintainerGrant(linkedCommon, grantId, {
+      sessionId: 'authority-session-fixture',
+      repositoryRoot: fs.realpathSync(linkedWorktree),
+      now: new Date('2026-07-16T12:05:00.000Z'),
+    });
+    assert.equal(reservation.state, 'reserved');
+    assert.equal(reservation.repositoryRoot, fs.realpathSync(linkedWorktree));
+    assert.throws(
+      () =>
+        reserveMaintainerGrant(commonDirectory, grantId, {
+          sessionId: 'authority-session-attacker',
+          repositoryRoot: fs.realpathSync(repository),
+        }),
+      (error) => isWorkflowError(error, 'ACTIVE_AUTHORITY_CONFLICT'),
+    );
+    assert.throws(
+      () =>
+        withRepositoryLifecycleOperation(
+          runtimePaths(commonDirectory, 'workflow-engine'),
+          () => undefined,
+        ),
+      (error) => isWorkflowError(error, 'ACTIVE_AUTHORITY_CONFLICT'),
+    );
+
+    const inspection = inspectMaintainerGrants(commonDirectory, grantId)[0];
+    assert.equal(inspection?.state, 'reserved');
+    assert.equal(inspection?.reservationSessionId, 'authority-session-fixture');
+    assert.equal(
+      JSON.stringify(inspection).includes(fs.realpathSync(linkedWorktree)),
+      false,
+    );
+    const store = maintainerGrantStorePaths(commonDirectory);
+    for (const directory of [
+      store.root,
+      store.available,
+      store.reserved,
+      store.terminal,
+      store.journals,
+    ]) {
+      assert.equal(fs.statSync(directory).mode & 0o777, 0o700);
+    }
+    assert.equal(
+      fs.statSync(path.join(store.reserved, `${grantId}.json`)).mode & 0o777,
+      0o600,
+    );
+    assert.equal(
+      fs.existsSync(path.join(linkedWorktree, 'workflow-engine')),
+      false,
+    );
+
+    const cli = path.join(
+      sourceRepositoryRoot,
+      'packages/workflow-engine/src/cli.ts',
+    );
+    const inspectedByCli = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        cli,
+        'maintainer',
+        'inspect',
+        grantId,
+        '--json',
+      ],
+      { cwd: linkedWorktree, encoding: 'utf8' },
+    );
+    assert.equal(inspectedByCli.status, 0);
+    assert.equal(inspectedByCli.stdout.includes(linkedWorktree), false);
+    assert.equal(JSON.parse(inspectedByCli.stdout).grants[0].state, 'reserved');
+
+    const revokedByCli = spawnSync(
+      process.execPath,
+      [
+        '--experimental-strip-types',
+        cli,
+        'maintainer',
+        'revoke',
+        grantId,
+        '--json',
+      ],
+      { cwd: linkedWorktree, encoding: 'utf8' },
+    );
+    assert.equal(revokedByCli.status, 0);
+    const revoked = JSON.parse(revokedByCli.stdout).grant;
+    const repeated = revokeMaintainerGrant(
+      linkedCommon,
+      grantId,
+      new Date('2026-07-16T12:07:00.000Z'),
+    );
+    assert.deepEqual(repeated, revoked);
+    assert.equal(revoked.state, 'revoked');
+    assert.equal(
+      fs.existsSync(path.join(store.reserved, `${grantId}.json`)),
+      false,
+    );
+    assert.equal(
+      fs.statSync(path.join(store.terminal, `${grantId}.json`)).mode & 0o777,
+      0o600,
+    );
+
+    const ambiguousReservation = path.join(store.reserved, 'attacker.tmp');
+    fs.writeFileSync(ambiguousReservation, 'untrusted', { mode: 0o600 });
+    assert.throws(
+      () =>
+        withRepositoryLifecycleOperation(
+          runtimePaths(commonDirectory, 'workflow-engine'),
+          () => undefined,
+        ),
+      (error) => isWorkflowError(error, 'MAINTAINER_GRANT_STORE_UNSAFE'),
+    );
+    fs.rmSync(ambiguousReservation);
+  } finally {
+    if (linkedWorktree && fs.existsSync(repository)) {
+      try {
+        git(repository, ['worktree', 'remove', '--force', linkedWorktree]);
+      } catch {
+        fs.rmSync(linkedWorktree, { recursive: true, force: true });
+      }
+    }
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
 function installFixtureMaintainerPolicy(repository: string): void {
   fs.writeFileSync(
     path.join(repository, 'workflow/maintainer-policy.json'),
@@ -444,4 +640,22 @@ function installFixtureMaintainerPolicy(repository: string): void {
   ]);
   git(repository, ['add', 'workflow/maintainer-policy.json']);
   git(repository, ['commit', '-m', 'Add maintainer fixture policy']);
+}
+
+function fixtureSigner(): MaintainerSignerProvider {
+  return {
+    assertHumanPresent() {},
+    identity() {
+      return 'fixture-maintainer';
+    },
+    sign() {
+      return [
+        '-----BEGIN SSH SIGNATURE-----',
+        'ZmFrZQ==',
+        '-----END SSH SIGNATURE-----',
+        '',
+      ].join('\n');
+    },
+    verify() {},
+  };
 }

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -54,6 +54,9 @@ import {
   recoverAuthorityCommit,
 } from '../src/maintainer-recovery.ts';
 import { commitFacts } from '../src/git-transitions.ts';
+import { validateCiAuthorityCommit } from '../src/ci-authority.ts';
+import { listRangeCommits } from '../src/ci-git.ts';
+import { replayCommitSequence } from '../src/ci-sequence.ts';
 
 const POLICY: MaintainerPolicy = {
   schemaVersion: 1,
@@ -816,7 +819,7 @@ test('authority commit signs the exact checked diff and consumes one grant', () 
       fixture.sessionId,
       'Repair exact authority',
       {
-        now: new Date('2026-07-16T12:03:00.000Z'),
+        now: fixtureTime(fixture, 30),
         signer: fixtureSigner(),
       },
     );
@@ -872,7 +875,7 @@ test('authority recovery completes a crash after signed commit creation', () => 
           fixture.sessionId,
           'Repair exact authority',
           {
-            now: new Date('2026-07-16T12:03:00.000Z'),
+            now: fixtureTime(fixture, 30),
             signer: fixtureSigner(),
             testCrashAfter: 'commit-created',
           },
@@ -892,7 +895,7 @@ test('authority recovery completes a crash after signed commit creation', () => 
     const recovered = recoverAuthorityCommit(
       fixture.repository,
       fixture.sessionId,
-      new Date('2026-07-16T12:04:00.000Z'),
+      fixtureTime(fixture, 40),
     );
     assert.equal(
       git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
@@ -903,7 +906,7 @@ test('authority recovery completes a crash after signed commit creation', () => 
       recoverAuthorityCommit(
         fixture.repository,
         fixture.sessionId,
-        new Date('2026-07-16T12:05:00.000Z'),
+        fixtureTime(fixture, 50),
       ).commitHash,
       recovered.commitHash,
     );
@@ -924,7 +927,7 @@ test('authority recovery finalizes a crash after the ref update', () => {
           fixture.sessionId,
           'Repair exact authority',
           {
-            now: new Date('2026-07-16T12:03:00.000Z'),
+            now: fixtureTime(fixture, 30),
             signer: fixtureSigner(),
             testCrashAfter: 'ref-updated',
           },
@@ -944,7 +947,7 @@ test('authority recovery finalizes a crash after the ref update', () => {
     const recovered = recoverAuthorityCommit(
       fixture.repository,
       fixture.sessionId,
-      new Date('2026-07-16T12:04:00.000Z'),
+      fixtureTime(fixture, 40),
     );
     assert.equal(recovered.commitHash, journal.commitHash);
     assert.equal(
@@ -969,7 +972,7 @@ test('ambiguous authority recovery revokes the use without a second commit', () 
           fixture.sessionId,
           'Repair exact authority',
           {
-            now: new Date('2026-07-16T12:03:00.000Z'),
+            now: fixtureTime(fixture, 30),
             signer: fixtureSigner(),
             testCrashAfter: 'commit-created',
           },
@@ -991,7 +994,7 @@ test('ambiguous authority recovery revokes the use without a second commit', () 
       recoverAuthorityCommit(
         fixture.repository,
         fixture.sessionId,
-        new Date('2026-07-16T12:04:00.000Z'),
+        fixtureTime(fixture, 40),
       ),
     );
     assert.equal(
@@ -1037,7 +1040,7 @@ test('untrusted commit signing key is rejected before the branch ref advances', 
         fixture.sessionId,
         'Repair exact authority',
         {
-          now: new Date('2026-07-16T12:03:00.000Z'),
+          now: fixtureTime(fixture, 30),
           signer: fixtureSigner(),
         },
       ),
@@ -1061,6 +1064,144 @@ test('untrusted commit signing key is rejected before the branch ref advances', 
   }
 });
 
+test('CI independently accepts one parent-policy authority claim', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  );
+  try {
+    const committed = commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Repair exact authority',
+      {
+        now: fixtureTime(fixture, 30),
+        signer: fixtureSigner(),
+      },
+    );
+    const [commit] = listRangeCommits(
+      fixture.repository,
+      fixture.baseCommit,
+      committed.commitHash,
+    );
+    assert.ok(commit);
+
+    const verified = validateCiAuthorityCommit(
+      fixture.repository,
+      commit,
+      fixtureTime(fixture, 40),
+    );
+    assert.equal(verified.grantId, fixture.grantId);
+    assert.equal(verified.changeId, 'demo-change');
+    assert.deepEqual(verified.allowedPaths, ['workflow/checks.json']);
+    assert.deepEqual(Object.keys(verified.requiredCheckDefinitions), [
+      'fixture',
+    ]);
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('CI rejects an authority claim without its exact protected audit tag', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+  );
+  try {
+    const committed = commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Repair exact authority',
+      {
+        now: fixtureTime(fixture, 30),
+        signer: fixtureSigner(),
+      },
+    );
+    const tagRef = `${fixture.policy.auditTagPrefix}${fixture.grantId}`;
+    git(fixture.repository, ['update-ref', '-d', tagRef]);
+    const [commit] = listRangeCommits(
+      fixture.repository,
+      fixture.baseCommit,
+      committed.commitHash,
+    );
+    assert.ok(commit);
+
+    assert.throws(
+      () =>
+        validateCiAuthorityCommit(
+          fixture.repository,
+          commit,
+          fixtureTime(fixture, 40),
+        ),
+      (error) => isWorkflowError(error, 'CI_AUTHORITY_AUDIT_TAG_INVALID'),
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('CI rejects a duplicate authority grant claim in one pull-request range', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'ffffffff-ffff-4fff-8fff-ffffffffffff',
+  );
+  try {
+    commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Repair exact authority',
+      {
+        now: fixtureTime(fixture, 30),
+        signer: fixtureSigner(),
+      },
+    );
+    const checksPath = path.join(fixture.repository, 'workflow/checks.json');
+    fs.writeFileSync(checksPath, ` ${fs.readFileSync(checksPath, 'utf8')}`);
+    git(fixture.repository, ['add', 'workflow/checks.json']);
+    git(fixture.repository, [
+      'commit',
+      '-S',
+      '-m',
+      'Replay exact authority',
+      '-m',
+      [
+        'Change: demo-change',
+        'Transition: authority-maintenance',
+        `Grant: ${fixture.grantId}`,
+      ].join('\n'),
+    ]);
+    const head = git(fixture.repository, ['rev-parse', 'HEAD']).trim();
+
+    assert.throws(
+      () =>
+        replayCommitSequence(
+          fixture.repository,
+          listRangeCommits(fixture.repository, fixture.baseCommit, head),
+          new Map(),
+          [],
+          [],
+          fixtureTime(fixture, 40),
+        ),
+      (error) => isWorkflowError(error, 'CI_AUTHORITY_GRANT_DUPLICATE'),
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('sealed parent policy rejects an immutable authority path', () => {
+  const policy: MaintainerPolicy = { ...POLICY, phase: 'sealed' };
+  const payload = grant({
+    allowedPaths: ['packages/workflow-engine/src/maintainer-policy.ts'],
+  });
+  assert.throws(
+    () =>
+      validateGrantPayload(payload, policy, {
+        now: new Date('2026-07-16T12:10:00.000Z'),
+        expectedBase: payload.baseCommit,
+        expectedPolicyBlob: payload.policyBlob,
+      }),
+    (error) => isWorkflowError(error, 'MAINTAINER_GRANT_INVALID'),
+  );
+});
+
 function installFixtureMaintainerPolicy(
   repository: string,
   policy: MaintainerPolicy = POLICY,
@@ -1082,10 +1223,13 @@ function installFixtureMaintainerPolicy(
 type AuthorityCommitFixture = {
   repository: string;
   signingDirectory: string;
+  privateKey: string;
   commonDirectory: string;
   grantId: string;
   sessionId: string;
   baseCommit: string;
+  now: Date;
+  policy: MaintainerPolicy;
 };
 
 function prepareAuthorityCommitFixture(
@@ -1137,6 +1281,7 @@ function prepareAuthorityCommitFixture(
   installFixtureMaintainerPolicy(repository, policy);
   git(repository, ['config', 'gpg.format', 'ssh']);
   git(repository, ['config', 'user.signingkey', privateKey]);
+  const now = new Date(Date.now() - 60_000);
   issueMaintainerGrant(
     repository,
     {
@@ -1145,30 +1290,37 @@ function prepareAuthorityCommitFixture(
       reason: 'Repair exact workflow authority',
     },
     {
-      now: new Date('2026-07-16T12:00:00.000Z'),
+      now,
       grantId,
-      signer: fixtureSigner(),
+      signer: fixtureSshSigner(privateKey, policy),
     },
   );
   git(repository, ['switch', '-c', 'work/demo-change']);
   const session = startAuthoritySession(repository, 'demo-change', grantId, {
-    now: new Date('2026-07-16T12:01:00.000Z'),
+    now: new Date(now.getTime() + 10_000),
     signer: fixtureSigner(),
   });
   const checksPath = path.join(repository, 'workflow/checks.json');
   fs.writeFileSync(checksPath, ` ${fs.readFileSync(checksPath, 'utf8')}`);
   checkAuthoritySession(repository, session.sessionId, {
-    now: new Date('2026-07-16T12:02:00.000Z'),
+    now: new Date(now.getTime() + 20_000),
     signer: fixtureSigner(),
   });
   return {
     repository,
     signingDirectory,
+    privateKey,
     commonDirectory: fs.realpathSync(path.join(repository, '.git')),
     grantId,
     sessionId: session.sessionId,
     baseCommit: session.baseCommit,
+    now,
+    policy,
   };
+}
+
+function fixtureTime(fixture: AuthorityCommitFixture, seconds: number): Date {
+  return new Date(fixture.now.getTime() + seconds * 1_000);
 }
 
 function cleanupAuthorityCommitFixture(fixture: AuthorityCommitFixture): void {
@@ -1191,5 +1343,79 @@ function fixtureSigner(): MaintainerSignerProvider {
       ].join('\n');
     },
     verify() {},
+  };
+}
+
+function fixtureSshSigner(
+  privateKey: string,
+  policy: MaintainerPolicy,
+): MaintainerSignerProvider {
+  const trusted = policy.trustedSigners[0];
+  assert.ok(trusted);
+  return {
+    assertHumanPresent() {},
+    identity() {
+      return trusted.identity;
+    },
+    sign(payload) {
+      const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'workflow-fixture-sign-'),
+      );
+      const payloadPath = path.join(directory, 'payload');
+      try {
+        fs.writeFileSync(payloadPath, payload, { mode: 0o600 });
+        const result = spawnSync(
+          '/usr/bin/ssh-keygen',
+          [
+            '-Y',
+            'sign',
+            '-f',
+            privateKey,
+            '-n',
+            policy.signatureNamespace,
+            payloadPath,
+          ],
+          { encoding: 'utf8' },
+        );
+        assert.equal(result.status, 0, result.stderr);
+        return fs.readFileSync(`${payloadPath}.sig`, 'utf8');
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
+    verify(payload, signature, identity) {
+      const directory = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'workflow-fixture-verify-'),
+      );
+      const allowedSigners = path.join(directory, 'allowed-signers');
+      const signaturePath = path.join(directory, 'signature');
+      try {
+        fs.writeFileSync(
+          allowedSigners,
+          `${trusted.identity} ${trusted.publicKey}\n`,
+          { mode: 0o600 },
+        );
+        fs.writeFileSync(signaturePath, signature, { mode: 0o600 });
+        const result = spawnSync(
+          '/usr/bin/ssh-keygen',
+          [
+            '-Y',
+            'verify',
+            '-f',
+            allowedSigners,
+            '-I',
+            identity,
+            '-n',
+            policy.signatureNamespace,
+            '-s',
+            signaturePath,
+          ],
+          { encoding: 'utf8', input: payload },
+        );
+        assert.equal(result.status, 0, result.stderr);
+      } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    },
   };
 }

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
@@ -6,9 +7,15 @@ import test from 'node:test';
 import {
   assertGrantPathsEligible,
   canonicalGrantPayload,
+  issueMaintainerGrant,
   validateGrantPayload,
+  type MaintainerGrantEnvelope,
   type MaintainerGrantPayload,
 } from '../src/maintainer-grant.ts';
+import {
+  assertInteractiveSignerContext,
+  type MaintainerSignerProvider,
+} from '../src/maintainer-signer.ts';
 import {
   loadMaintainerPolicy,
   parseMaintainerPolicy,
@@ -205,3 +212,236 @@ test('grant paths require exact-case tracked regular eligible files', () => {
     fs.rmSync(repository, { recursive: true, force: true });
   }
 });
+
+test('grant signer requires controlling input and output terminals', () => {
+  for (const context of [
+    { stdinIsTty: false, stdoutIsTty: true, stderrIsTty: true },
+    { stdinIsTty: true, stdoutIsTty: false, stderrIsTty: true },
+    { stdinIsTty: true, stdoutIsTty: true, stderrIsTty: false },
+  ]) {
+    assert.throws(
+      () => assertInteractiveSignerContext(context),
+      (error) => isWorkflowError(error, 'MAINTAINER_INTERACTIVE_REQUIRED'),
+    );
+  }
+  assert.doesNotThrow(() =>
+    assertInteractiveSignerContext({
+      stdinIsTty: true,
+      stdoutIsTty: true,
+      stderrIsTty: true,
+    }),
+  );
+});
+
+test('maintainer grant CLI rejects non-interactive and unattended issuance', () => {
+  const repository = createFixtureRepository();
+  const cli = path.join(
+    sourceRepositoryRoot,
+    'packages/workflow-engine/src/cli.ts',
+  );
+  const validArguments = [
+    '--experimental-strip-types',
+    cli,
+    'maintainer',
+    'grant',
+    '--change',
+    'demo-change',
+    '--paths',
+    'workflow/checks.json',
+    '--reason',
+    'Repair exact workflow authority',
+    '--json',
+  ];
+  try {
+    installFixtureMaintainerPolicy(repository);
+    const nonInteractive = spawnSync(process.execPath, validArguments, {
+      cwd: repository,
+      encoding: 'utf8',
+    });
+    assert.equal(nonInteractive.status, 12);
+    assert.equal(
+      JSON.parse(nonInteractive.stderr).error.code,
+      'MAINTAINER_INTERACTIVE_REQUIRED',
+    );
+
+    const unattended = spawnSync(
+      process.execPath,
+      [...validArguments.slice(0, -1), '--unattended', '--json'],
+      { cwd: repository, encoding: 'utf8' },
+    );
+    assert.equal(unattended.status, 2);
+    assert.equal(JSON.parse(unattended.stderr).error.code, 'INVALID_USAGE');
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('grant issuance signs canonical bytes and writes only common-dir state and an audit tag', () => {
+  const repository = createFixtureRepository();
+  const now = new Date('2026-07-16T12:00:00.000Z');
+  const grantId = '22222222-2222-4222-8222-222222222222';
+  const signedInputs: string[] = [];
+  const verified: MaintainerGrantEnvelope[] = [];
+  const signer: MaintainerSignerProvider = {
+    assertHumanPresent() {},
+    identity() {
+      return 'fixture-maintainer';
+    },
+    sign(payload) {
+      signedInputs.push(payload);
+      return [
+        '-----BEGIN SSH SIGNATURE-----',
+        'ZmFrZQ==',
+        '-----END SSH SIGNATURE-----',
+        '',
+      ].join('\n');
+    },
+    verify(payload, signature, identity) {
+      verified.push({ payload: JSON.parse(payload), signature });
+      assert.equal(identity, 'fixture-maintainer');
+    },
+  };
+
+  try {
+    installFixtureMaintainerPolicy(repository);
+    const result = issueMaintainerGrant(
+      repository,
+      {
+        changeId: 'demo-change',
+        paths: ['workflow/checks.json'],
+        reason: 'Repair exact workflow authority',
+      },
+      { now, grantId, signer },
+    );
+
+    assert.equal(result.grantId, grantId);
+    assert.equal(result.tagRef, `refs/tags/workflow-grant/${grantId}`);
+    assert.equal(
+      result.publishCommand,
+      `git push origin ${result.tagRef}:${result.tagRef}`,
+    );
+    assert.equal(signedInputs.length, 1);
+    assert.equal(verified.length, 1);
+    assert.equal(
+      signedInputs[0],
+      canonicalGrantPayload(result.envelope.payload),
+    );
+    assert.equal(
+      result.envelope.payload.baseCommit,
+      git(repository, ['rev-parse', 'HEAD']).trim(),
+    );
+    assert.equal(
+      result.envelope.payload.policyBlob,
+      git(repository, [
+        'rev-parse',
+        'HEAD:workflow/maintainer-policy.json',
+      ]).trim(),
+    );
+    assert.equal(result.envelope.payload.expiresAt, '2026-07-16T12:30:00.000Z');
+    assert.equal(result.envelope.payload.maxUses, 1);
+
+    const available = path.join(
+      repository,
+      '.git/workflow-engine/maintainer-grants/available',
+      `${grantId}.json`,
+    );
+    assert.equal(fs.statSync(available).mode & 0o777, 0o600);
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(available, 'utf8')),
+      result.envelope,
+    );
+    const rawTag = git(repository, ['cat-file', 'tag', result.tagRef]);
+    assert.equal(
+      rawTag.slice(rawTag.indexOf('\n\n') + 2),
+      `${JSON.stringify(result.envelope)}\n`,
+    );
+    assert.equal(git(repository, ['status', '--porcelain']).trim(), '');
+
+    assert.throws(
+      () =>
+        issueMaintainerGrant(
+          repository,
+          {
+            changeId: 'demo-change',
+            paths: ['workflow/checks.json'],
+            reason: 'Repair exact workflow authority',
+          },
+          { now, grantId, signer },
+        ),
+      (error) => isWorkflowError(error, 'MAINTAINER_GRANT_EXISTS'),
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('failed signature verification leaves no token or audit tag', () => {
+  const repository = createFixtureRepository();
+  const grantId = '33333333-3333-4333-8333-333333333333';
+  const signer: MaintainerSignerProvider = {
+    assertHumanPresent() {},
+    identity() {
+      return 'fixture-maintainer';
+    },
+    sign() {
+      return [
+        '-----BEGIN SSH SIGNATURE-----',
+        'YmFk',
+        '-----END SSH SIGNATURE-----',
+        '',
+      ].join('\n');
+    },
+    verify() {
+      throw new Error('altered signature');
+    },
+  };
+
+  try {
+    installFixtureMaintainerPolicy(repository);
+    assert.throws(() =>
+      issueMaintainerGrant(
+        repository,
+        {
+          changeId: 'demo-change',
+          paths: ['workflow/checks.json'],
+          reason: 'Repair exact workflow authority',
+        },
+        {
+          now: new Date('2026-07-16T12:00:00.000Z'),
+          grantId,
+          signer,
+        },
+      ),
+    );
+    assert.equal(
+      fs.existsSync(
+        path.join(
+          repository,
+          '.git/workflow-engine/maintainer-grants/available',
+          `${grantId}.json`,
+        ),
+      ),
+      false,
+    );
+    assert.throws(() =>
+      git(repository, ['rev-parse', `refs/tags/workflow-grant/${grantId}`]),
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+function installFixtureMaintainerPolicy(repository: string): void {
+  fs.writeFileSync(
+    path.join(repository, 'workflow/maintainer-policy.json'),
+    `${JSON.stringify(POLICY, null, 2)}\n`,
+  );
+  git(repository, [
+    'remote',
+    'add',
+    'origin',
+    'https://github.com/example/fixture.git',
+  ]);
+  git(repository, ['add', 'workflow/maintainer-policy.json']);
+  git(repository, ['commit', '-m', 'Add maintainer fixture policy']);
+}

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
@@ -44,6 +45,15 @@ import {
   startAuthoritySession,
 } from '../src/maintainer-session.ts';
 import { readImmutableReport } from '../src/report-store.ts';
+import {
+  commitAuthoritySession,
+  SimulatedAuthorityCrash,
+} from '../src/maintainer-commit.ts';
+import {
+  readAuthorityCommitJournal,
+  recoverAuthorityCommit,
+} from '../src/maintainer-recovery.ts';
+import { commitFacts } from '../src/git-transitions.ts';
 
 const POLICY: MaintainerPolicy = {
   schemaVersion: 1,
@@ -796,10 +806,268 @@ test('authority session state cannot broaden signed paths or remove pinned check
   }
 });
 
-function installFixtureMaintainerPolicy(repository: string): void {
+test('authority commit signs the exact checked diff and consumes one grant', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    '88888888-8888-4888-8888-888888888888',
+  );
+  try {
+    const result = commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Repair exact authority',
+      {
+        now: new Date('2026-07-16T12:03:00.000Z'),
+        signer: fixtureSigner(),
+      },
+    );
+    const facts = commitFacts(fixture.repository, result.commitHash);
+    assert.deepEqual(facts.parents, [fixture.baseCommit]);
+    assert.equal(
+      facts.message,
+      [
+        'Repair exact authority',
+        '',
+        'Change: demo-change',
+        'Transition: authority-maintenance',
+        `Grant: ${fixture.grantId}`,
+        '',
+      ].join('\n'),
+    );
+    assert.equal(git(fixture.repository, ['status', '--porcelain']).trim(), '');
+    assert.equal(
+      readAuthoritySession(fixture.repository, fixture.sessionId).state,
+      'committed',
+    );
+    assert.equal(
+      inspectMaintainerGrants(fixture.commonDirectory, fixture.grantId)[0]
+        ?.state,
+      'consumed',
+    );
+    assert.equal(
+      readAuthorityCommitJournal(fixture.commonDirectory, fixture.sessionId)
+        .state,
+      'consumed',
+    );
+    assert.match(
+      fs.readFileSync(
+        path.join(fixture.repository, 'openspec/changes/demo-change/tasks.md'),
+        'utf8',
+      ),
+      /- \[ \] 1\.1/,
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('authority recovery completes a crash after signed commit creation', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    '99999999-9999-4999-8999-999999999999',
+  );
+  try {
+    assert.throws(
+      () =>
+        commitAuthoritySession(
+          fixture.repository,
+          fixture.sessionId,
+          'Repair exact authority',
+          {
+            now: new Date('2026-07-16T12:03:00.000Z'),
+            signer: fixtureSigner(),
+            testCrashAfter: 'commit-created',
+          },
+        ),
+      SimulatedAuthorityCrash,
+    );
+    assert.equal(
+      git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
+      fixture.baseCommit,
+    );
+    assert.equal(
+      readAuthorityCommitJournal(fixture.commonDirectory, fixture.sessionId)
+        .state,
+      'commit-created',
+    );
+
+    const recovered = recoverAuthorityCommit(
+      fixture.repository,
+      fixture.sessionId,
+      new Date('2026-07-16T12:04:00.000Z'),
+    );
+    assert.equal(
+      git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
+      recovered.commitHash,
+    );
+    assert.equal(recovered.journalState, 'consumed');
+    assert.equal(
+      recoverAuthorityCommit(
+        fixture.repository,
+        fixture.sessionId,
+        new Date('2026-07-16T12:05:00.000Z'),
+      ).commitHash,
+      recovered.commitHash,
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('authority recovery finalizes a crash after the ref update', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  );
+  try {
+    assert.throws(
+      () =>
+        commitAuthoritySession(
+          fixture.repository,
+          fixture.sessionId,
+          'Repair exact authority',
+          {
+            now: new Date('2026-07-16T12:03:00.000Z'),
+            signer: fixtureSigner(),
+            testCrashAfter: 'ref-updated',
+          },
+        ),
+      SimulatedAuthorityCrash,
+    );
+    const journal = readAuthorityCommitJournal(
+      fixture.commonDirectory,
+      fixture.sessionId,
+    );
+    assert.equal(journal.state, 'ref-updated');
+    assert.equal(
+      git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
+      journal.commitHash,
+    );
+
+    const recovered = recoverAuthorityCommit(
+      fixture.repository,
+      fixture.sessionId,
+      new Date('2026-07-16T12:04:00.000Z'),
+    );
+    assert.equal(recovered.commitHash, journal.commitHash);
+    assert.equal(
+      inspectMaintainerGrants(fixture.commonDirectory, fixture.grantId)[0]
+        ?.state,
+      'consumed',
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('ambiguous authority recovery revokes the use without a second commit', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+  );
+  try {
+    assert.throws(
+      () =>
+        commitAuthoritySession(
+          fixture.repository,
+          fixture.sessionId,
+          'Repair exact authority',
+          {
+            now: new Date('2026-07-16T12:03:00.000Z'),
+            signer: fixtureSigner(),
+            testCrashAfter: 'commit-created',
+          },
+        ),
+      SimulatedAuthorityCrash,
+    );
+    const journalPath = path.join(
+      fixture.commonDirectory,
+      'workflow-engine/maintainer-grants/journals',
+      `${fixture.sessionId}.json`,
+    );
+    const altered = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+    altered.commitHash = 'c'.repeat(40);
+    fs.writeFileSync(journalPath, `${JSON.stringify(altered)}\n`, {
+      mode: 0o600,
+    });
+
+    assert.throws(() =>
+      recoverAuthorityCommit(
+        fixture.repository,
+        fixture.sessionId,
+        new Date('2026-07-16T12:04:00.000Z'),
+      ),
+    );
+    assert.equal(
+      git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
+      fixture.baseCommit,
+    );
+    assert.equal(
+      inspectMaintainerGrants(fixture.commonDirectory, fixture.grantId)[0]
+        ?.state,
+      'revoked',
+    );
+    assert.equal(
+      readAuthoritySession(fixture.repository, fixture.sessionId).state,
+      'failed',
+    );
+    assert.equal(
+      readAuthorityCommitJournal(fixture.commonDirectory, fixture.sessionId)
+        .state,
+      'revoked',
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('untrusted commit signing key is rejected before the branch ref advances', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+  );
+  try {
+    const untrustedKey = path.join(fixture.signingDirectory, 'untrusted');
+    const generated = spawnSync(
+      '/usr/bin/ssh-keygen',
+      ['-q', '-t', 'ed25519', '-N', '', '-C', 'untrusted', '-f', untrustedKey],
+      { encoding: 'utf8' },
+    );
+    assert.equal(generated.status, 0, generated.stderr);
+    git(fixture.repository, ['config', 'user.signingkey', untrustedKey]);
+
+    assert.throws(() =>
+      commitAuthoritySession(
+        fixture.repository,
+        fixture.sessionId,
+        'Repair exact authority',
+        {
+          now: new Date('2026-07-16T12:03:00.000Z'),
+          signer: fixtureSigner(),
+        },
+      ),
+    );
+    assert.equal(
+      git(fixture.repository, ['rev-parse', 'HEAD']).trim(),
+      fixture.baseCommit,
+    );
+    assert.equal(
+      inspectMaintainerGrants(fixture.commonDirectory, fixture.grantId)[0]
+        ?.state,
+      'revoked',
+    );
+    assert.equal(
+      readAuthorityCommitJournal(fixture.commonDirectory, fixture.sessionId)
+        .state,
+      'revoked',
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+function installFixtureMaintainerPolicy(
+  repository: string,
+  policy: MaintainerPolicy = POLICY,
+): void {
   fs.writeFileSync(
     path.join(repository, 'workflow/maintainer-policy.json'),
-    `${JSON.stringify(POLICY, null, 2)}\n`,
+    `${JSON.stringify(policy, null, 2)}\n`,
   );
   git(repository, [
     'remote',
@@ -809,6 +1077,103 @@ function installFixtureMaintainerPolicy(repository: string): void {
   ]);
   git(repository, ['add', 'workflow/maintainer-policy.json']);
   git(repository, ['commit', '-m', 'Add maintainer fixture policy']);
+}
+
+type AuthorityCommitFixture = {
+  repository: string;
+  signingDirectory: string;
+  commonDirectory: string;
+  grantId: string;
+  sessionId: string;
+  baseCommit: string;
+};
+
+function prepareAuthorityCommitFixture(
+  grantId: string,
+): AuthorityCommitFixture {
+  const repository = createFixtureRepository();
+  const signingDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-authority-key-'),
+  );
+  const privateKey = path.join(signingDirectory, 'id_ed25519');
+  const generated = spawnSync(
+    '/usr/bin/ssh-keygen',
+    [
+      '-q',
+      '-t',
+      'ed25519',
+      '-N',
+      '',
+      '-C',
+      'fixture-maintainer',
+      '-f',
+      privateKey,
+    ],
+    { encoding: 'utf8' },
+  );
+  assert.equal(generated.status, 0, generated.stderr);
+  const publicKey = fs
+    .readFileSync(`${privateKey}.pub`, 'utf8')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .join(' ');
+  const fingerprintOutput = spawnSync(
+    '/usr/bin/ssh-keygen',
+    ['-l', '-E', 'sha256', '-f', `${privateKey}.pub`],
+    { encoding: 'utf8' },
+  );
+  assert.equal(fingerprintOutput.status, 0, fingerprintOutput.stderr);
+  const fingerprint = fingerprintOutput.stdout.match(
+    /SHA256:[A-Za-z0-9+/]+/,
+  )?.[0];
+  assert.ok(fingerprint);
+  const policy: MaintainerPolicy = {
+    ...POLICY,
+    trustedSigners: [
+      { identity: 'fixture-maintainer', publicKey, fingerprint },
+    ],
+  };
+  installFixtureMaintainerPolicy(repository, policy);
+  git(repository, ['config', 'gpg.format', 'ssh']);
+  git(repository, ['config', 'user.signingkey', privateKey]);
+  issueMaintainerGrant(
+    repository,
+    {
+      changeId: 'demo-change',
+      paths: ['workflow/checks.json'],
+      reason: 'Repair exact workflow authority',
+    },
+    {
+      now: new Date('2026-07-16T12:00:00.000Z'),
+      grantId,
+      signer: fixtureSigner(),
+    },
+  );
+  git(repository, ['switch', '-c', 'work/demo-change']);
+  const session = startAuthoritySession(repository, 'demo-change', grantId, {
+    now: new Date('2026-07-16T12:01:00.000Z'),
+    signer: fixtureSigner(),
+  });
+  const checksPath = path.join(repository, 'workflow/checks.json');
+  fs.writeFileSync(checksPath, ` ${fs.readFileSync(checksPath, 'utf8')}`);
+  checkAuthoritySession(repository, session.sessionId, {
+    now: new Date('2026-07-16T12:02:00.000Z'),
+    signer: fixtureSigner(),
+  });
+  return {
+    repository,
+    signingDirectory,
+    commonDirectory: fs.realpathSync(path.join(repository, '.git')),
+    grantId,
+    sessionId: session.sessionId,
+    baseCommit: session.baseCommit,
+  };
+}
+
+function cleanupAuthorityCommitFixture(fixture: AuthorityCommitFixture): void {
+  fs.rmSync(fixture.repository, { recursive: true, force: true });
+  fs.rmSync(fixture.signingDirectory, { recursive: true, force: true });
 }
 
 function fixtureSigner(): MaintainerSignerProvider {

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -38,6 +38,12 @@ import {
   runtimePaths,
   withRepositoryLifecycleOperation,
 } from '../src/session-store.ts';
+import {
+  checkAuthoritySession,
+  readAuthoritySession,
+  startAuthoritySession,
+} from '../src/maintainer-session.ts';
+import { readImmutableReport } from '../src/report-store.ts';
 
 const POLICY: MaintainerPolicy = {
   schemaVersion: 1,
@@ -623,6 +629,169 @@ test('common-dir reservation is exclusive across worktrees and revocation is ide
         fs.rmSync(linkedWorktree, { recursive: true, force: true });
       }
     }
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('authority session pins normal checks and terminally revokes failed scope', () => {
+  const repository = createFixtureRepository();
+  const grantId = '55555555-5555-4555-8555-555555555555';
+  const now = new Date('2026-07-16T12:00:00.000Z');
+  try {
+    installFixtureMaintainerPolicy(repository);
+    issueMaintainerGrant(
+      repository,
+      {
+        changeId: 'demo-change',
+        paths: ['workflow/checks.json'],
+        reason: 'Repair exact workflow authority',
+      },
+      { now, grantId, signer: fixtureSigner() },
+    );
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    const session = startAuthoritySession(repository, 'demo-change', grantId, {
+      now: new Date('2026-07-16T12:01:00.000Z'),
+      signer: fixtureSigner(),
+    });
+    assert.deepEqual(session.requiredChecks, ['fixture']);
+    assert.equal(session.pinnedChecks[0]?.runner.digest.length, 64);
+
+    const checksPath = path.join(repository, 'workflow/checks.json');
+    fs.writeFileSync(checksPath, ` ${fs.readFileSync(checksPath, 'utf8')}`);
+    const checked = checkAuthoritySession(repository, session.sessionId, {
+      now: new Date('2026-07-16T12:02:00.000Z'),
+      signer: fixtureSigner(),
+    });
+    assert.equal(checked.passed, true);
+    assert.deepEqual(checked.changedPaths, ['workflow/checks.json']);
+    const commonDirectory = fs.realpathSync(path.join(repository, '.git'));
+    const store = maintainerGrantStorePaths(commonDirectory);
+    const report = readImmutableReport(
+      store.runtime.reports,
+      session.sessionId,
+      checked.reportId,
+    );
+    assert.equal(report.kind, 'authority-check');
+    assert.equal(report.grantId, grantId);
+    assert.equal(
+      readAuthoritySession(repository, session.sessionId).state,
+      'active',
+    );
+
+    fs.writeFileSync(path.join(repository, 'src/unexpected.ts'), 'unsafe\n');
+    assert.throws(
+      () =>
+        checkAuthoritySession(repository, session.sessionId, {
+          now: new Date('2026-07-16T12:03:00.000Z'),
+          signer: fixtureSigner(),
+        }),
+      (error) => isWorkflowError(error, 'AUTHORITY_SCOPE_INVALID'),
+    );
+    assert.equal(
+      readAuthoritySession(repository, session.sessionId).state,
+      'failed',
+    );
+    assert.equal(
+      inspectMaintainerGrants(commonDirectory, grantId)[0]?.state,
+      'revoked',
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('authority start failure after reservation never returns the grant to available', () => {
+  const repository = createFixtureRepository();
+  const grantId = '66666666-6666-4666-8666-666666666666';
+  try {
+    installFixtureMaintainerPolicy(repository);
+    const issued = issueMaintainerGrant(
+      repository,
+      {
+        changeId: 'demo-change',
+        paths: ['workflow/checks.json'],
+        reason: 'Repair exact workflow authority',
+      },
+      {
+        now: new Date('2026-07-16T12:00:00.000Z'),
+        grantId,
+        signer: fixtureSigner(),
+      },
+    );
+    git(repository, ['update-ref', '-d', issued.tagRef]);
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    assert.throws(
+      () =>
+        startAuthoritySession(repository, 'demo-change', grantId, {
+          now: new Date('2026-07-16T12:01:00.000Z'),
+          signer: fixtureSigner(),
+        }),
+      (error) => isWorkflowError(error, 'AUTHORITY_AUDIT_TAG_INVALID'),
+    );
+    const commonDirectory = fs.realpathSync(path.join(repository, '.git'));
+    assert.equal(
+      inspectMaintainerGrants(commonDirectory, grantId)[0]?.state,
+      'revoked',
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});
+
+test('authority session state cannot broaden signed paths or remove pinned checks', () => {
+  const repository = createFixtureRepository();
+  const grantId = '77777777-7777-4777-8777-777777777777';
+  try {
+    installFixtureMaintainerPolicy(repository);
+    issueMaintainerGrant(
+      repository,
+      {
+        changeId: 'demo-change',
+        paths: ['workflow/checks.json'],
+        reason: 'Repair exact workflow authority',
+      },
+      {
+        now: new Date('2026-07-16T12:00:00.000Z'),
+        grantId,
+        signer: fixtureSigner(),
+      },
+    );
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    const session = startAuthoritySession(repository, 'demo-change', grantId, {
+      now: new Date('2026-07-16T12:01:00.000Z'),
+      signer: fixtureSigner(),
+    });
+    const sessionPath = path.join(
+      session.gitCommonDirectory,
+      'workflow-engine/maintainer-grants/sessions',
+      `${session.sessionId}.json`,
+    );
+    const altered = JSON.parse(fs.readFileSync(sessionPath, 'utf8'));
+    altered.allowedPaths.push('src/unexpected.ts');
+    altered.requiredChecks = [];
+    altered.pinnedChecks = [];
+    fs.writeFileSync(sessionPath, `${JSON.stringify(altered)}\n`, {
+      mode: 0o600,
+    });
+    fs.writeFileSync(
+      path.join(repository, 'workflow/checks.json'),
+      ` ${fs.readFileSync(path.join(repository, 'workflow/checks.json'), 'utf8')}`,
+    );
+    fs.writeFileSync(path.join(repository, 'src/unexpected.ts'), 'unsafe\n');
+
+    assert.throws(
+      () =>
+        checkAuthoritySession(repository, session.sessionId, {
+          now: new Date('2026-07-16T12:02:00.000Z'),
+          signer: fixtureSigner(),
+        }),
+      (error) => isWorkflowError(error, 'AUTHORITY_SESSION_MISMATCH'),
+    );
+    assert.equal(
+      inspectMaintainerGrants(session.gitCommonDirectory, grantId)[0]?.state,
+      'revoked',
+    );
+  } finally {
     fs.rmSync(repository, { recursive: true, force: true });
   }
 });

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -7,6 +7,7 @@ import test from 'node:test';
 
 import {
   assertGrantPathsEligible,
+  canonicalGrantEnvelope,
   canonicalGrantPayload,
   issueMaintainerGrant,
   validateGrantPayload,
@@ -72,10 +73,12 @@ const POLICY: MaintainerPolicy = {
   bootstrapEligiblePaths: [
     'packages/workflow-engine/src/**',
     'workflow/checks.json',
+    'workflow/maintainer-policy.json',
     'workflow/schemas/**',
   ],
   sealedImmutablePaths: [
     'packages/workflow-engine/src/maintainer-policy.ts',
+    'workflow/maintainer-policy.json',
     'workflow/schemas/maintainer-policy.schema.json',
   ],
   requiredChecks: ['fixture'],
@@ -1186,20 +1189,251 @@ test('CI rejects a duplicate authority grant claim in one pull-request range', (
   }
 });
 
-test('sealed parent policy rejects an immutable authority path', () => {
-  const policy: MaintainerPolicy = { ...POLICY, phase: 'sealed' };
-  const payload = grant({
-    allowedPaths: ['packages/workflow-engine/src/maintainer-policy.ts'],
-  });
-  assert.throws(
-    () =>
-      validateGrantPayload(payload, policy, {
-        now: new Date('2026-07-16T12:10:00.000Z'),
-        expectedBase: payload.baseCommit,
-        expectedPolicyBlob: payload.policyBlob,
-      }),
-    (error) => isWorkflowError(error, 'MAINTAINER_GRANT_INVALID'),
+test('CI accepts an old-key-authorized trusted signer rotation', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    '12121212-1212-4212-8212-121212121212',
+    {
+      allowedPath: 'workflow/maintainer-policy.json',
+      mutate(repository, policy) {
+        const rotated: MaintainerPolicy = {
+          ...policy,
+          trustedSigners: POLICY.trustedSigners,
+        };
+        fs.writeFileSync(
+          path.join(repository, 'workflow/maintainer-policy.json'),
+          `${JSON.stringify(rotated, null, 2)}\n`,
+        );
+      },
+    },
   );
+  try {
+    const committed = commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Rotate trusted maintainer key',
+      {
+        now: fixtureTime(fixture, 30),
+        signer: fixtureSigner(),
+      },
+    );
+    const [commit] = listRangeCommits(
+      fixture.repository,
+      fixture.baseCommit,
+      committed.commitHash,
+    );
+    assert.ok(commit);
+
+    assert.doesNotThrow(() =>
+      validateCiAuthorityCommit(
+        fixture.repository,
+        commit,
+        fixtureTime(fixture, 40),
+      ),
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('CI rejects a candidate key that attempts to trust its own grant', () => {
+  const repository = createFixtureRepository();
+  const signingDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-candidate-key-'),
+  );
+  try {
+    const oldKey = generateFixtureSshKey(
+      signingDirectory,
+      'old',
+      'fixture-maintainer',
+    );
+    const candidateKey = generateFixtureSshKey(
+      signingDirectory,
+      'candidate',
+      'fixture-maintainer',
+    );
+    const parentPolicy: MaintainerPolicy = {
+      ...POLICY,
+      trustedSigners: [oldKey.trustedSigner],
+    };
+    installFixtureMaintainerPolicy(repository, parentPolicy);
+    const base = git(repository, ['rev-parse', 'HEAD']).trim();
+    const grantId = '13131313-1313-4313-8313-131313131313';
+    const now = new Date(Date.now() - 60_000);
+    const payload: MaintainerGrantPayload = {
+      version: 1,
+      grantId,
+      repositoryId: parentPolicy.repository.id,
+      repositoryOrigin: parentPolicy.repository.origin,
+      baseCommit: base,
+      policyBlob: git(repository, [
+        'rev-parse',
+        `${base}:workflow/maintainer-policy.json`,
+      ]).trim(),
+      changeId: 'demo-change',
+      allowedPaths: ['workflow/maintainer-policy.json'],
+      issuedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 30 * 60_000).toISOString(),
+      maxUses: 1,
+      reason: 'Attempt candidate-controlled signer rotation',
+      signer: candidateKey.trustedSigner.identity,
+    };
+    const signature = fixtureSshSigner(candidateKey.privateKey, {
+      ...parentPolicy,
+      trustedSigners: [candidateKey.trustedSigner],
+    }).sign(canonicalGrantPayload(payload));
+    writeFixtureAuditTag(repository, base, grantId, {
+      payload,
+      signature,
+    });
+
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    fs.writeFileSync(
+      path.join(repository, 'workflow/maintainer-policy.json'),
+      `${JSON.stringify(
+        { ...parentPolicy, trustedSigners: [candidateKey.trustedSigner] },
+        null,
+        2,
+      )}\n`,
+    );
+    git(repository, ['config', 'gpg.format', 'ssh']);
+    git(repository, ['config', 'user.signingkey', candidateKey.privateKey]);
+    git(repository, ['add', 'workflow/maintainer-policy.json']);
+    git(repository, [
+      'commit',
+      '-S',
+      '-m',
+      'Attempt candidate signer rotation',
+      '-m',
+      [
+        'Change: demo-change',
+        'Transition: authority-maintenance',
+        `Grant: ${grantId}`,
+      ].join('\n'),
+    ]);
+    const head = git(repository, ['rev-parse', 'HEAD']).trim();
+    const [commit] = listRangeCommits(repository, base, head);
+    assert.ok(commit);
+
+    assert.throws(
+      () => validateCiAuthorityCommit(repository, commit, new Date()),
+      (error) => isWorkflowError(error, 'CI_AUTHORITY_GRANT_SIGNATURE_INVALID'),
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+    fs.rmSync(signingDirectory, { recursive: true, force: true });
+  }
+});
+
+test('CI rejects an authority grant that expires while the PR is evaluated', () => {
+  const fixture = prepareAuthorityCommitFixture(
+    '14141414-1414-4414-8414-141414141414',
+  );
+  try {
+    const committed = commitAuthoritySession(
+      fixture.repository,
+      fixture.sessionId,
+      'Repair exact authority',
+      {
+        now: fixtureTime(fixture, 30),
+        signer: fixtureSigner(),
+      },
+    );
+    const [commit] = listRangeCommits(
+      fixture.repository,
+      fixture.baseCommit,
+      committed.commitHash,
+    );
+    assert.ok(commit);
+
+    assert.throws(
+      () =>
+        validateCiAuthorityCommit(
+          fixture.repository,
+          commit,
+          fixtureTime(fixture, 30 * 60 + 1),
+        ),
+      (error) => isWorkflowError(error, 'MAINTAINER_GRANT_EXPIRED'),
+    );
+  } finally {
+    cleanupAuthorityCommitFixture(fixture);
+  }
+});
+
+test('CI rejects a sealed-to-bootstrap phase rollback from parent policy', () => {
+  const repository = createFixtureRepository();
+  const signingDirectory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-sealed-rollback-'),
+  );
+  try {
+    const key = generateFixtureSshKey(
+      signingDirectory,
+      'sealed',
+      'fixture-maintainer',
+    );
+    const parentPolicy: MaintainerPolicy = {
+      ...POLICY,
+      phase: 'sealed',
+      trustedSigners: [key.trustedSigner],
+    };
+    installFixtureMaintainerPolicy(repository, parentPolicy);
+    const base = git(repository, ['rev-parse', 'HEAD']).trim();
+    const grantId = '15151515-1515-4515-8515-151515151515';
+    const now = new Date(Date.now() - 60_000);
+    const payload: MaintainerGrantPayload = {
+      version: 1,
+      grantId,
+      repositoryId: parentPolicy.repository.id,
+      repositoryOrigin: parentPolicy.repository.origin,
+      baseCommit: base,
+      policyBlob: git(repository, [
+        'rev-parse',
+        `${base}:workflow/maintainer-policy.json`,
+      ]).trim(),
+      changeId: 'demo-change',
+      allowedPaths: ['workflow/maintainer-policy.json'],
+      issuedAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + 30 * 60_000).toISOString(),
+      maxUses: 1,
+      reason: 'Attempt sealed maintainer policy rollback',
+      signer: key.trustedSigner.identity,
+    };
+    const signature = fixtureSshSigner(key.privateKey, parentPolicy).sign(
+      canonicalGrantPayload(payload),
+    );
+    writeFixtureAuditTag(repository, base, grantId, { payload, signature });
+
+    git(repository, ['switch', '-c', 'work/demo-change']);
+    fs.writeFileSync(
+      path.join(repository, 'workflow/maintainer-policy.json'),
+      `${JSON.stringify({ ...parentPolicy, phase: 'bootstrap' }, null, 2)}\n`,
+    );
+    git(repository, ['config', 'gpg.format', 'ssh']);
+    git(repository, ['config', 'user.signingkey', key.privateKey]);
+    git(repository, ['add', 'workflow/maintainer-policy.json']);
+    git(repository, [
+      'commit',
+      '-S',
+      '-m',
+      'Attempt sealed policy rollback',
+      '-m',
+      [
+        'Change: demo-change',
+        'Transition: authority-maintenance',
+        `Grant: ${grantId}`,
+      ].join('\n'),
+    ]);
+    const head = git(repository, ['rev-parse', 'HEAD']).trim();
+    const [commit] = listRangeCommits(repository, base, head);
+    assert.ok(commit);
+
+    assert.throws(
+      () => validateCiAuthorityCommit(repository, commit, new Date()),
+      (error) => isWorkflowError(error, 'MAINTAINER_GRANT_INVALID'),
+    );
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+    fs.rmSync(signingDirectory, { recursive: true, force: true });
+  }
 });
 
 function installFixtureMaintainerPolicy(
@@ -1232,8 +1466,18 @@ type AuthorityCommitFixture = {
   policy: MaintainerPolicy;
 };
 
+type AuthorityCommitFixtureOptions = {
+  allowedPath?: string;
+  mutate?: (
+    repository: string,
+    policy: MaintainerPolicy,
+    signingDirectory: string,
+  ) => void;
+};
+
 function prepareAuthorityCommitFixture(
   grantId: string,
+  options: AuthorityCommitFixtureOptions = {},
 ): AuthorityCommitFixture {
   const repository = createFixtureRepository();
   const signingDirectory = fs.mkdtempSync(
@@ -1282,11 +1526,12 @@ function prepareAuthorityCommitFixture(
   git(repository, ['config', 'gpg.format', 'ssh']);
   git(repository, ['config', 'user.signingkey', privateKey]);
   const now = new Date(Date.now() - 60_000);
+  const allowedPath = options.allowedPath ?? 'workflow/checks.json';
   issueMaintainerGrant(
     repository,
     {
       changeId: 'demo-change',
-      paths: ['workflow/checks.json'],
+      paths: [allowedPath],
       reason: 'Repair exact workflow authority',
     },
     {
@@ -1300,8 +1545,12 @@ function prepareAuthorityCommitFixture(
     now: new Date(now.getTime() + 10_000),
     signer: fixtureSigner(),
   });
-  const checksPath = path.join(repository, 'workflow/checks.json');
-  fs.writeFileSync(checksPath, ` ${fs.readFileSync(checksPath, 'utf8')}`);
+  if (options.mutate) {
+    options.mutate(repository, policy, signingDirectory);
+  } else {
+    const targetPath = path.join(repository, allowedPath);
+    fs.writeFileSync(targetPath, ` ${fs.readFileSync(targetPath, 'utf8')}`);
+  }
   checkAuthoritySession(repository, session.sessionId, {
     now: new Date(now.getTime() + 20_000),
     signer: fixtureSigner(),
@@ -1344,6 +1593,71 @@ function fixtureSigner(): MaintainerSignerProvider {
     },
     verify() {},
   };
+}
+
+function generateFixtureSshKey(
+  directory: string,
+  basename: string,
+  identity: string,
+): {
+  privateKey: string;
+  trustedSigner: MaintainerPolicy['trustedSigners'][number];
+} {
+  const privateKey = path.join(directory, basename);
+  const generated = spawnSync(
+    '/usr/bin/ssh-keygen',
+    ['-q', '-t', 'ed25519', '-N', '', '-C', identity, '-f', privateKey],
+    { encoding: 'utf8' },
+  );
+  assert.equal(generated.status, 0, generated.stderr);
+  const publicKey = fs
+    .readFileSync(`${privateKey}.pub`, 'utf8')
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .join(' ');
+  const fingerprintResult = spawnSync(
+    '/usr/bin/ssh-keygen',
+    ['-l', '-E', 'sha256', '-f', `${privateKey}.pub`],
+    { encoding: 'utf8' },
+  );
+  assert.equal(fingerprintResult.status, 0, fingerprintResult.stderr);
+  const fingerprint = fingerprintResult.stdout.match(
+    /SHA256:[A-Za-z0-9+/]+/,
+  )?.[0];
+  assert.ok(fingerprint);
+  return {
+    privateKey,
+    trustedSigner: { identity, publicKey, fingerprint },
+  };
+}
+
+function writeFixtureAuditTag(
+  repository: string,
+  base: string,
+  grantId: string,
+  envelope: MaintainerGrantEnvelope,
+): void {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'workflow-fixture-tag-'),
+  );
+  const messagePath = path.join(directory, 'message');
+  try {
+    fs.writeFileSync(messagePath, canonicalGrantEnvelope(envelope), {
+      mode: 0o600,
+    });
+    git(repository, [
+      'tag',
+      '--annotate',
+      '--cleanup=verbatim',
+      '--file',
+      messagePath,
+      `workflow-grant/${grantId}`,
+      base,
+    ]);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 }
 
 function fixtureSshSigner(

--- a/packages/workflow-engine/test/maintainer-mode.integration.test.ts
+++ b/packages/workflow-engine/test/maintainer-mode.integration.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  assertGrantPathsEligible,
+  canonicalGrantPayload,
+  validateGrantPayload,
+  type MaintainerGrantPayload,
+} from '../src/maintainer-grant.ts';
+import {
+  loadMaintainerPolicy,
+  parseMaintainerPolicy,
+  type MaintainerPolicy,
+} from '../src/maintainer-policy.ts';
+import {
+  createFixtureRepository,
+  git,
+  isWorkflowError,
+  sourceRepositoryRoot,
+} from './fixture.ts';
+
+const POLICY: MaintainerPolicy = {
+  schemaVersion: 1,
+  repository: {
+    id: 'github:R_fixture',
+    origin: 'https://github.com/example/fixture.git',
+  },
+  phase: 'bootstrap',
+  auditTagPrefix: 'refs/tags/workflow-grant/',
+  signatureNamespace: 'expense-app.workflow.maintainer-grant.v1',
+  maxTtlMinutes: 30,
+  maxUses: 1,
+  bootstrapEligiblePaths: [
+    'packages/workflow-engine/src/**',
+    'workflow/checks.json',
+    'workflow/schemas/**',
+  ],
+  sealedImmutablePaths: [
+    'packages/workflow-engine/src/maintainer-policy.ts',
+    'workflow/schemas/maintainer-policy.schema.json',
+  ],
+  requiredChecks: ['fixture'],
+  trustedSigners: [
+    {
+      identity: 'fixture-maintainer',
+      publicKey:
+        'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJL6dVljsgm9EAbjCiOhA/tKsgApOhKmcB/NRewL1uns',
+      fingerprint: 'SHA256:7UB1aHADtIMUJBFt3sjo9RwoBDgCKc1B1GlEucUDL4U',
+    },
+  ],
+};
+
+function grant(
+  overrides: Partial<MaintainerGrantPayload> = {},
+): MaintainerGrantPayload {
+  return {
+    version: 1,
+    grantId: '11111111-1111-4111-8111-111111111111',
+    repositoryId: POLICY.repository.id,
+    repositoryOrigin: POLICY.repository.origin,
+    baseCommit: 'a'.repeat(40),
+    policyBlob: 'b'.repeat(40),
+    changeId: 'demo-change',
+    allowedPaths: ['workflow/checks.json'],
+    issuedAt: '2026-07-16T12:00:00.000Z',
+    expiresAt: '2026-07-16T12:30:00.000Z',
+    maxUses: 1,
+    reason: 'Repair exact workflow authority',
+    signer: 'fixture-maintainer',
+    ...overrides,
+  };
+}
+
+test('repository maintainer policy is strict, stable, and bootstrap-scoped', () => {
+  const policy = loadMaintainerPolicy(sourceRepositoryRoot);
+
+  assert.equal(policy.repository.id, 'github:R_kgDOOotVag');
+  assert.equal(
+    policy.repository.origin,
+    'https://github.com/tomchen86/expense-app.git',
+  );
+  assert.equal(policy.phase, 'bootstrap');
+  assert.equal(policy.maxTtlMinutes, 30);
+  assert.equal(policy.maxUses, 1);
+  assert.deepEqual(
+    policy.trustedSigners.map(({ identity }) => identity),
+    ['tomchen86'],
+  );
+  assert.ok(
+    policy.sealedImmutablePaths.includes(
+      'packages/workflow-engine/src/maintainer-policy.ts',
+    ),
+  );
+});
+
+test('maintainer policy rejects unknown, unordered, and self-removable trust', () => {
+  assert.throws(
+    () => parseMaintainerPolicy({ ...POLICY, unexpected: true }),
+    (error) => isWorkflowError(error, 'MAINTAINER_POLICY_INVALID'),
+  );
+  assert.throws(
+    () =>
+      parseMaintainerPolicy({
+        ...POLICY,
+        bootstrapEligiblePaths: [...POLICY.bootstrapEligiblePaths].reverse(),
+      }),
+    (error) => isWorkflowError(error, 'MAINTAINER_POLICY_INVALID'),
+  );
+  assert.throws(
+    () =>
+      parseMaintainerPolicy({
+        ...POLICY,
+        sealedImmutablePaths: ['workflow/not-eligible.json'],
+      }),
+    (error) => isWorkflowError(error, 'MAINTAINER_POLICY_INVALID'),
+  );
+});
+
+test('grant payload serialization is canonical and validates every bound field', () => {
+  const payload = grant();
+  assert.equal(canonicalGrantPayload(payload), `${JSON.stringify(payload)}\n`);
+  assert.doesNotThrow(() =>
+    validateGrantPayload(payload, POLICY, {
+      now: new Date('2026-07-16T12:10:00.000Z'),
+      expectedBase: payload.baseCommit,
+      expectedPolicyBlob: payload.policyBlob,
+    }),
+  );
+
+  for (const invalid of [
+    grant({ repositoryId: 'github:other' }),
+    grant({ baseCommit: 'short' }),
+    grant({ policyBlob: 'c'.repeat(40) }),
+    grant({ allowedPaths: ['workflow/schemas/**'] }),
+    grant({ allowedPaths: ['workflow/checks.json', 'workflow/checks.json'] }),
+    grant({ expiresAt: '2026-07-16T12:31:00.000Z' }),
+    grant({ maxUses: 2 as 1 }),
+    grant({ reason: 'short' }),
+    grant({ signer: 'candidate-key' }),
+  ]) {
+    assert.throws(
+      () =>
+        validateGrantPayload(invalid, POLICY, {
+          now: new Date('2026-07-16T12:10:00.000Z'),
+          expectedBase: 'a'.repeat(40),
+          expectedPolicyBlob: 'b'.repeat(40),
+        }),
+      (error) => isWorkflowError(error, 'MAINTAINER_GRANT_INVALID'),
+    );
+  }
+});
+
+test('grant expiry is fail-closed unless historical validation is explicit', () => {
+  const payload = grant();
+  assert.throws(
+    () =>
+      validateGrantPayload(payload, POLICY, {
+        now: new Date('2026-07-16T12:30:00.001Z'),
+        expectedBase: payload.baseCommit,
+        expectedPolicyBlob: payload.policyBlob,
+      }),
+    (error) => isWorkflowError(error, 'MAINTAINER_GRANT_EXPIRED'),
+  );
+  assert.doesNotThrow(() =>
+    validateGrantPayload(payload, POLICY, {
+      now: new Date('2026-07-16T12:30:00.001Z'),
+      expectedBase: payload.baseCommit,
+      expectedPolicyBlob: payload.policyBlob,
+      allowExpired: true,
+    }),
+  );
+});
+
+test('grant paths require exact-case tracked regular eligible files', () => {
+  const repository = createFixtureRepository();
+  try {
+    assert.deepEqual(
+      assertGrantPathsEligible(repository, ['workflow/checks.json'], POLICY),
+      ['workflow/checks.json'],
+    );
+
+    fs.symlinkSync(
+      path.join(repository, 'workflow/checks.json'),
+      path.join(repository, 'workflow/checks-link.json'),
+    );
+    git(repository, ['add', 'workflow/checks-link.json']);
+    git(repository, ['commit', '-m', 'Add unsafe authority symlink']);
+
+    for (const paths of [
+      ['workflow/*.json'],
+      ['workflow'],
+      ['Workflow/checks.json'],
+      ['workflow/checks-link.json'],
+      ['src/.gitkeep'],
+      ['../workflow/checks.json'],
+    ]) {
+      assert.throws(
+        () => assertGrantPathsEligible(repository, paths, POLICY),
+        (error) => isWorkflowError(error, 'MAINTAINER_GRANT_PATH_INVALID'),
+      );
+    }
+  } finally {
+    fs.rmSync(repository, { recursive: true, force: true });
+  }
+});

--- a/packages/workflow-engine/test/managed-trailers.contract.test.ts
+++ b/packages/workflow-engine/test/managed-trailers.contract.test.ts
@@ -13,6 +13,17 @@ test('managed trailer parser returns one canonical transition kind', () => {
   );
   assert.deepEqual(
     parseManagedTrailers(
+      'Repair authority\n\nChange: demo-change\nTransition: authority-maintenance\nGrant: 11111111-1111-4111-8111-111111111111\n',
+    ),
+    {
+      kind: 'authority',
+      changeId: 'demo-change',
+      transition: 'authority-maintenance',
+      grantId: '11111111-1111-4111-8111-111111111111',
+    },
+  );
+  assert.deepEqual(
+    parseManagedTrailers(
       'Plan demo-change\n\nChange: demo-change\nTransition: plan\n',
     ),
     { kind: 'plan', changeId: 'demo-change', transition: 'plan' },
@@ -60,6 +71,9 @@ test('managed trailer parser rejects every non-canonical reserved block', () => 
     'Missing pair\n\nChange: demo-change\n',
     'Missing pair\n\nTask: 1.1\n',
     'Missing pair\n\nTransition: archive\n',
+    'Missing grant\n\nChange: demo-change\nTransition: authority-maintenance\n',
+    'Mixed authority\n\nChange: demo-change\nTask: 1.1\nTransition: authority-maintenance\nGrant: 11111111-1111-4111-8111-111111111111\n',
+    'Bad grant\n\nChange: demo-change\nTransition: authority-maintenance\nGrant: not-a-grant\n',
   ];
 
   for (const message of invalidMessages) {

--- a/packages/workflow-engine/test/session.integration.test.ts
+++ b/packages/workflow-engine/test/session.integration.test.ts
@@ -21,6 +21,7 @@ import './document-refresh.integration.test.ts';
 import './guard-contract.integration.test.ts';
 import './hooks.integration.test.ts';
 import './managed-trailers.contract.test.ts';
+import './maintainer-mode.integration.test.ts';
 import './ci.integration.test.ts';
 import './ci-bootstrap.integration.test.ts';
 import './ai-adapter-evaluation.integration.test.ts';

--- a/workflow/maintainer-policy.json
+++ b/workflow/maintainer-policy.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "repository": {
+    "id": "github:R_kgDOOotVag",
+    "origin": "https://github.com/tomchen86/expense-app.git"
+  },
+  "phase": "bootstrap",
+  "auditTagPrefix": "refs/tags/workflow-grant/",
+  "signatureNamespace": "expense-app.workflow.maintainer-grant.v1",
+  "maxTtlMinutes": 30,
+  "maxUses": 1,
+  "bootstrapEligiblePaths": [
+    ".github/workflows/workflow-assurance.yml",
+    "packages/workflow-engine/src/**",
+    "workflow/ai-adapter-policy.json",
+    "workflow/checks.json",
+    "workflow/ci-policy.json",
+    "workflow/config.json",
+    "workflow/document-policy.json",
+    "workflow/maintainer-policy.json",
+    "workflow/schemas/**"
+  ],
+  "sealedImmutablePaths": [
+    ".github/workflows/workflow-assurance.yml",
+    "packages/workflow-engine/src/ci-authority.ts",
+    "packages/workflow-engine/src/ci.ts",
+    "packages/workflow-engine/src/maintainer-grant.ts",
+    "packages/workflow-engine/src/maintainer-policy.ts",
+    "packages/workflow-engine/src/maintainer-signer.ts",
+    "packages/workflow-engine/src/managed-trailers.ts",
+    "workflow/maintainer-policy.json",
+    "workflow/schemas/maintainer-grant.schema.json",
+    "workflow/schemas/maintainer-policy.schema.json"
+  ],
+  "requiredChecks": [
+    "managed-documents",
+    "workflow-format",
+    "workflow-lint",
+    "workflow-tests",
+    "workflow-typecheck"
+  ],
+  "trustedSigners": [
+    {
+      "identity": "tomchen86",
+      "publicKey": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJL6dVljsgm9EAbjCiOhA/tKsgApOhKmcB/NRewL1uns",
+      "fingerprint": "SHA256:7UB1aHADtIMUJBFt3sjo9RwoBDgCKc1B1GlEucUDL4U"
+    }
+  ]
+}

--- a/workflow/schemas/maintainer-grant.schema.json
+++ b/workflow/schemas/maintainer-grant.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://expense-app.local/workflow/maintainer-grant.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["payload", "signature"],
+  "properties": {
+    "payload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "grantId",
+        "repositoryId",
+        "repositoryOrigin",
+        "baseCommit",
+        "policyBlob",
+        "changeId",
+        "allowedPaths",
+        "issuedAt",
+        "expiresAt",
+        "maxUses",
+        "reason",
+        "signer"
+      ],
+      "properties": {
+        "version": { "const": 1 },
+        "grantId": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "repositoryId": {
+          "type": "string",
+          "pattern": "^github:[A-Za-z0-9_-]+$"
+        },
+        "repositoryOrigin": {
+          "type": "string",
+          "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\\.git$"
+        },
+        "baseCommit": { "$ref": "#/$defs/commitOid" },
+        "policyBlob": { "$ref": "#/$defs/commitOid" },
+        "changeId": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+        },
+        "allowedPaths": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*[\\\\*?\\[\\]{}!])[^\\u0000-\\u001F\\u007F-\\u009F]+$"
+          }
+        },
+        "issuedAt": { "type": "string", "format": "date-time" },
+        "expiresAt": { "type": "string", "format": "date-time" },
+        "maxUses": { "const": 1 },
+        "reason": { "type": "string", "minLength": 12, "maxLength": 500 },
+        "signer": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9._@+-]{0,127}$"
+        }
+      }
+    },
+    "signature": {
+      "type": "string",
+      "minLength": 64,
+      "maxLength": 16384
+    }
+  },
+  "$defs": {
+    "commitOid": {
+      "type": "string",
+      "pattern": "^(?:[0-9a-f]{40}|[0-9a-f]{64})$"
+    }
+  }
+}

--- a/workflow/schemas/maintainer-policy.schema.json
+++ b/workflow/schemas/maintainer-policy.schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://expense-app.local/workflow/maintainer-policy.schema.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "repository",
+    "phase",
+    "auditTagPrefix",
+    "signatureNamespace",
+    "maxTtlMinutes",
+    "maxUses",
+    "bootstrapEligiblePaths",
+    "sealedImmutablePaths",
+    "requiredChecks",
+    "trustedSigners"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "origin"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^github:[A-Za-z0-9_-]+$" },
+        "origin": {
+          "type": "string",
+          "pattern": "^https://github\\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+\\.git$"
+        }
+      }
+    },
+    "phase": { "enum": ["bootstrap", "sealed"] },
+    "auditTagPrefix": {
+      "type": "string",
+      "pattern": "^refs/tags/[a-z0-9][a-z0-9-]*/$"
+    },
+    "signatureNamespace": {
+      "const": "expense-app.workflow.maintainer-grant.v1"
+    },
+    "maxTtlMinutes": { "const": 30 },
+    "maxUses": { "const": 1 },
+    "bootstrapEligiblePaths": { "$ref": "#/$defs/policyPaths" },
+    "sealedImmutablePaths": { "$ref": "#/$defs/policyPaths" },
+    "requiredChecks": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"
+      }
+    },
+    "trustedSigners": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["identity", "publicKey", "fingerprint"],
+        "properties": {
+          "identity": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._@+-]{0,127}$"
+          },
+          "publicKey": {
+            "type": "string",
+            "pattern": "^ssh-(?:ed25519|ed25519-sk|rsa|ecdsa-[^ ]+) [A-Za-z0-9+/]+={0,2}$"
+          },
+          "fingerprint": {
+            "type": "string",
+            "pattern": "^SHA256:[A-Za-z0-9+/]{20,}$"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "policyPaths": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "pattern": "^(?!/)(?![A-Za-z]:[\\\\/])(?!.*(?:^|/)\\.{1,2}(?:/|$))(?!.*//)(?!.*\\\\)(?!.*[?\\[\\]{}!])[^*]+(?:/\\*\\*)?$"
+      }
+    }
+  }
+}

--- a/workflow/schemas/report.schema.json
+++ b/workflow/schemas/report.schema.json
@@ -5,7 +5,8 @@
     { "$ref": "#/$defs/check" },
     { "$ref": "#/$defs/completion" },
     { "$ref": "#/$defs/finish" },
-    { "$ref": "#/$defs/commit" }
+    { "$ref": "#/$defs/commit" },
+    { "$ref": "#/$defs/authorityCheck" }
   ],
   "$defs": {
     "digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
@@ -25,7 +26,9 @@
       ],
       "properties": {
         "schemaVersion": { "const": 1 },
-        "kind": { "enum": ["check", "completion", "finish", "commit"] },
+        "kind": {
+          "enum": ["check", "completion", "finish", "commit", "authority-check"]
+        },
         "sessionId": { "type": "string" },
         "changeId": { "type": "string" },
         "taskId": { "type": "string" },
@@ -121,6 +124,51 @@
             "projectionSourceDigest",
             "transitionPaths",
             "message"
+          ]
+        }
+      ]
+    },
+    "authorityCheck": {
+      "allOf": [
+        { "$ref": "#/$defs/base" },
+        {
+          "properties": {
+            "kind": { "const": "authority-check" },
+            "grantId": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+            },
+            "baseCommit": { "$ref": "#/$defs/commitHash" },
+            "policyBlob": { "$ref": "#/$defs/commitHash" },
+            "contractDigest": { "$ref": "#/$defs/digest" },
+            "allowedPaths": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "changedPaths": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "requiredChecks": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "checks": {
+              "type": "array",
+              "items": { "type": "object" }
+            },
+            "fingerprint": { "$ref": "#/$defs/digest" }
+          },
+          "required": [
+            "grantId",
+            "baseCommit",
+            "policyBlob",
+            "contractDigest",
+            "allowedPaths",
+            "changedPaths",
+            "requiredChecks",
+            "checks",
+            "fingerprint"
           ]
         }
       ]


### PR DESCRIPTION
## Summary

- define canonical, short-lived, single-use maintainer grants bound to the exact repository, base policy, OpenSpec change, paths, expiry, reason, and trusted SSH signer
- require controlling-terminal human presence, create signed non-secret audit tags, and keep grant/session/journal state in the Git common directory
- add exact-path authority start/check/commit, terminal abort/revocation, durable fail-closed recovery, and a mutually exclusive authority-maintenance commit form
- replay authority commits with parent/base policy, signer, audit-tag, expiry, phase, immutable-path, unique-use, signature, and complete-check verification
- run workflow assurance from the exact pull-request base while checking out candidate code separately without persisted credentials
- document every operator command, bootstrap pilot, remote prerequisite, recovery boundary, signer rotation, and the one-way transition to sealed mode

## Bootstrap boundary

This implementation PR is intentionally an ordinary managed change: its base does not yet contain the maintainer policy or trusted-base verifier, so it contains no authority-maintenance commit. The new `pull_request_target` definition becomes base-owned only after merge.

The checked-in facility remains **bootstrap-only** until a maintainer independently verifies protected `workflow-grant/**` tags, the required base-owned `workflow-assurance` check, up-to-date/no-bypass branch rules, and the protected-environment approval for sealing. Repository files do not prove those remote settings.

## Verification

- all OpenSpec tasks 1.1 through 5.1 completed through the managed workflow lifecycle
- Task 5.1 formal checks passed: workflow tests, typecheck, lint, format, and managed documents
- operator-contract suite passed 54/54 after first proving the documentation gap as RED
- Task 4.1 GitHub checkpoint passed `workflow-assurance` before the workflow event definition changed
- Task 4.2 and Task 5.1 local base/candidate assurance, attack, recovery, project contract, typecheck, lint, and format coverage passed
- latest regular GitHub API, Web, Mobile, Prettier, and review checks are being monitored on the final push

No API database tests were run or required; this change has no product or database behavior.
